### PR TITLE
feat: add session migration commands (move/copy between workspaces)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,8 @@ Tool calls are stored in `toolFormerData`:
 | `exportSessionToMarkdown(index, config?)` | Export single session to Markdown string |
 | `exportAllSessionsToJson(config?)` | Export all sessions to JSON array string |
 | `exportAllSessionsToMarkdown(config?)` | Export all sessions to Markdown string |
+| `migrateSession(config)` | Move/copy sessions to another workspace |
+| `migrateWorkspace(config)` | Move/copy all sessions between workspaces |
 | `getDefaultDataPath()` | Get platform-specific Cursor data path |
 
 ### Configuration (`LibraryConfig`)
@@ -233,6 +235,8 @@ try {
 | `show <index>` | Show session details (-s/--short, -t/--think, -f/--fullread, -e/--error) |
 | `search <query>` | Search across sessions (-n, --context) |
 | `export [index]` | Export to md/json (--all, -o, -f, --force) |
+| `migrate-session <session> <dest>` | Move/copy session(s) to workspace (--copy, --dry-run, -f) |
+| `migrate <source> <dest>` | Move/copy all sessions between workspaces (--copy, --dry-run, -f) |
 
 ### Show Command Options
 
@@ -288,6 +292,7 @@ Edit `extractBubbleText()` in `src/core/storage.ts`. Priority matters:
 - better-sqlite3 for SQLite database access (read-only)
 - commander + picocolors for CLI (not used in library)
 - Dual ESM/CommonJS module support
+- TypeScript 5.9+ (strict mode enabled) + better-sqlite3, commander, picocolors, node:fs (for workspace.json writes) (003-migrate-workspace)
 
 ## Recent Changes
 - 002-library-api: Added library API for programmatic access

--- a/specs/003-migrate-workspace/checklists/requirements.md
+++ b/specs/003-migrate-workspace/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Migrate Workspace History
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-12-24
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All checklist items pass validation
+- Specification is ready for `/speckit.clarify` or `/speckit.plan`
+- Two modes (move/copy) clearly specified as requested by user
+- Library API included for developer usage as requested

--- a/specs/003-migrate-workspace/contracts/api.ts
+++ b/specs/003-migrate-workspace/contracts/api.ts
@@ -1,0 +1,311 @@
+/**
+ * Migration API Contracts
+ *
+ * TypeScript interfaces for the migrate-session and migrate commands.
+ * These define the library API surface for programmatic migration.
+ */
+
+// ============================================================================
+// Core Types
+// ============================================================================
+
+/**
+ * Migration mode: move removes from source, copy keeps source intact
+ */
+export type MigrationMode = 'move' | 'copy';
+
+/**
+ * Error codes for migration failures
+ */
+export type MigrationErrorCode =
+  | 'SESSION_NOT_FOUND'
+  | 'WORKSPACE_NOT_FOUND'
+  | 'SAME_WORKSPACE'
+  | 'DATABASE_LOCKED'
+  | 'PERMISSION_DENIED'
+  | 'MIGRATION_FAILED';
+
+// ============================================================================
+// Session-Level Migration (Core Primitive)
+// ============================================================================
+
+/**
+ * Options for migrating one or more sessions by ID/index
+ */
+export interface MigrateSessionOptions {
+  /**
+   * Session identifier(s) to migrate.
+   * Can be:
+   * - Single session ID (UUID): "abc123-def456"
+   * - Single index (1-based): "3" or 3
+   * - Multiple comma-separated: "1,3,5" or "abc123,def456"
+   * - Array of IDs/indices: ["1", "3"] or [1, 3]
+   */
+  sessions: string | number | (string | number)[];
+
+  /**
+   * Destination workspace path (absolute or relative)
+   */
+  destination: string;
+
+  /**
+   * Migration mode: 'move' (default) or 'copy'
+   * - move: Remove session from source, add to destination
+   * - copy: Keep session in source, add copy to destination (new ID)
+   */
+  mode?: MigrationMode;
+
+  /**
+   * If true, show what would happen without making changes
+   */
+  dryRun?: boolean;
+
+  /**
+   * If true, proceed even if destination has existing history
+   */
+  force?: boolean;
+
+  /**
+   * Custom Cursor data path (optional, uses default if not specified)
+   */
+  dataPath?: string;
+}
+
+/**
+ * Result of migrating a single session
+ */
+export interface SessionMigrationResult {
+  /** Whether migration succeeded */
+  success: boolean;
+
+  /** Original session ID */
+  sessionId: string;
+
+  /** Source workspace path */
+  sourceWorkspace: string;
+
+  /** Destination workspace path */
+  destinationWorkspace: string;
+
+  /** Mode used for migration */
+  mode: MigrationMode;
+
+  /** For copy mode: the new session ID created */
+  newSessionId?: string;
+
+  /** Error details if success is false */
+  error?: MigrationError;
+
+  /** Whether this was a dry run */
+  dryRun: boolean;
+}
+
+// ============================================================================
+// Workspace-Level Migration (Wrapper)
+// ============================================================================
+
+/**
+ * Options for migrating all sessions from one workspace to another
+ */
+export interface MigrateWorkspaceOptions {
+  /**
+   * Source workspace path to migrate from (exact match)
+   */
+  source: string;
+
+  /**
+   * Destination workspace path to migrate to
+   */
+  destination: string;
+
+  /**
+   * Migration mode: 'move' (default) or 'copy'
+   */
+  mode?: MigrationMode;
+
+  /**
+   * If true, show what would happen without making changes
+   */
+  dryRun?: boolean;
+
+  /**
+   * If true, proceed even if destination has existing history
+   */
+  force?: boolean;
+
+  /**
+   * Custom Cursor data path (optional)
+   */
+  dataPath?: string;
+}
+
+/**
+ * Aggregate result of workspace migration
+ */
+export interface WorkspaceMigrationResult {
+  /** True if all sessions migrated successfully */
+  success: boolean;
+
+  /** Normalized source path */
+  source: string;
+
+  /** Normalized destination path */
+  destination: string;
+
+  /** Mode used for migration */
+  mode: MigrationMode;
+
+  /** Total number of sessions attempted */
+  totalSessions: number;
+
+  /** Number of successful migrations */
+  successCount: number;
+
+  /** Number of failed migrations */
+  failureCount: number;
+
+  /** Per-session results */
+  results: SessionMigrationResult[];
+
+  /** Whether this was a dry run */
+  dryRun: boolean;
+}
+
+// ============================================================================
+// Error Types
+// ============================================================================
+
+/**
+ * Detailed error information for migration failures
+ */
+export interface MigrationError {
+  /** Error code for programmatic handling */
+  code: MigrationErrorCode;
+
+  /** Human-readable error message */
+  message: string;
+
+  /** Session ID that failed (if applicable) */
+  sessionId?: string;
+
+  /** Additional error context */
+  details?: Record<string, unknown>;
+}
+
+/**
+ * Error thrown when a session ID/index cannot be resolved
+ */
+export class SessionNotFoundError extends Error {
+  readonly code = 'SESSION_NOT_FOUND' as const;
+  constructor(public readonly identifier: string | number) {
+    super(`Session not found: ${identifier}`);
+    this.name = 'SessionNotFoundError';
+  }
+}
+
+/**
+ * Error thrown when destination workspace path has no workspace directory
+ */
+export class WorkspaceNotFoundError extends Error {
+  readonly code = 'WORKSPACE_NOT_FOUND' as const;
+  constructor(public readonly path: string) {
+    super(`No workspace found for path: ${path}. Please open the project in Cursor first.`);
+    this.name = 'WorkspaceNotFoundError';
+  }
+}
+
+/**
+ * Error thrown when source and destination are the same
+ */
+export class SameWorkspaceError extends Error {
+  readonly code = 'SAME_WORKSPACE' as const;
+  constructor(public readonly path: string) {
+    super(`Source and destination are the same: ${path}`);
+    this.name = 'SameWorkspaceError';
+  }
+}
+
+// ============================================================================
+// Library API Functions
+// ============================================================================
+
+/**
+ * Migrate one or more sessions to a new workspace.
+ *
+ * This is the core primitive - migrateWorkspace() uses this internally.
+ *
+ * @example
+ * // Move a single session by index
+ * const result = migrateSession({ sessions: 1, destination: '/new/project' });
+ *
+ * @example
+ * // Move multiple sessions
+ * const result = migrateSession({ sessions: '1,3,5', destination: '/new/project' });
+ *
+ * @example
+ * // Copy a session (keeps original)
+ * const result = migrateSession({
+ *   sessions: 'abc123',
+ *   destination: '/new/project',
+ *   mode: 'copy'
+ * });
+ *
+ * @example
+ * // Dry run to preview
+ * const result = migrateSession({
+ *   sessions: 1,
+ *   destination: '/new/project',
+ *   dryRun: true
+ * });
+ */
+export declare function migrateSession(
+  options: MigrateSessionOptions
+): SessionMigrationResult[];
+
+/**
+ * Migrate all sessions from one workspace to another.
+ *
+ * Internally calls migrateSession() for each session found in the source workspace.
+ *
+ * @example
+ * // Move all history from old project to new
+ * const result = migrateWorkspace({
+ *   source: '/old/project',
+ *   destination: '/new/project'
+ * });
+ *
+ * @example
+ * // Copy all history (backup)
+ * const result = migrateWorkspace({
+ *   source: '/project',
+ *   destination: '/project-backup',
+ *   mode: 'copy'
+ * });
+ *
+ * @example
+ * // Force migration even if destination has sessions
+ * const result = migrateWorkspace({
+ *   source: '/old/project',
+ *   destination: '/existing/project',
+ *   force: true
+ * });
+ */
+export declare function migrateWorkspace(
+  options: MigrateWorkspaceOptions
+): WorkspaceMigrationResult;
+
+// ============================================================================
+// Type Guards
+// ============================================================================
+
+export function isSessionNotFoundError(err: unknown): err is SessionNotFoundError {
+  return err instanceof Error && err.name === 'SessionNotFoundError';
+}
+
+export function isWorkspaceNotFoundError(err: unknown): err is WorkspaceNotFoundError {
+  return err instanceof Error && err.name === 'WorkspaceNotFoundError';
+}
+
+export function isSameWorkspaceError(err: unknown): err is SameWorkspaceError {
+  return err instanceof Error && err.name === 'SameWorkspaceError';
+}

--- a/specs/003-migrate-workspace/data-model.md
+++ b/specs/003-migrate-workspace/data-model.md
@@ -1,0 +1,325 @@
+# Data Model: Migrate Workspace History
+
+**Feature**: 003-migrate-workspace
+**Date**: 2025-12-24
+**Updated**: 2025-12-24 (revised for session-level architecture)
+
+## Entities
+
+### SessionIdentifier
+
+Represents how a session can be identified for migration.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `value` | `string \| number` | Either a session UUID (string) or 1-based index (number) |
+| `type` | `'id' \| 'index'` | Resolved type of identifier |
+
+**Resolution rules**:
+- If numeric and within valid index range → treat as index
+- Otherwise → treat as UUID
+- Comma-separated values allowed: `1,3,5` or `abc123,def456`
+
+---
+
+### MigrateSessionOptions
+
+Configuration options for single/multiple session migration (core primitive).
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `sessions` | `string \| string[]` | Yes | - | Session ID(s) or index(es) to migrate |
+| `destination` | `string` | Yes | - | Destination workspace path |
+| `mode` | `'move' \| 'copy'` | No | `'move'` | Migration mode |
+| `dryRun` | `boolean` | No | `false` | Preview changes without applying |
+| `force` | `boolean` | No | `false` | Proceed even if destination has existing history |
+
+**Validation Rules**:
+- Each session identifier must resolve to an existing session
+- `destination` must be a valid path (resolved to absolute)
+- For `mode: 'copy'`, new session IDs are generated
+
+---
+
+### MigrateWorkspaceOptions
+
+Configuration options for workspace-level migration (wrapper over session migration).
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `source` | `string` | Yes | - | Source workspace path to migrate from |
+| `destination` | `string` | Yes | - | Destination workspace path to migrate to |
+| `mode` | `'move' \| 'copy'` | No | `'move'` | Migration mode |
+| `dryRun` | `boolean` | No | `false` | Preview changes without applying |
+| `force` | `boolean` | No | `false` | Proceed even if destination has existing history |
+
+**Validation Rules**:
+- `source` must match at least one session's workspace path (exact match)
+- `source` and `destination` must differ (after path normalization)
+
+---
+
+### SessionMigrationResult
+
+Outcome of a single session migration.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `success` | `boolean` | Whether the migration completed successfully |
+| `sessionId` | `string` | UUID of the migrated session |
+| `sourceWorkspace` | `string` | Original workspace path |
+| `destinationWorkspace` | `string` | New workspace path |
+| `mode` | `'move' \| 'copy'` | The mode used |
+| `newSessionId` | `string?` | For copy mode: the ID of the new session |
+| `error` | `MigrationError?` | Error details if `success` is false |
+| `dryRun` | `boolean` | Whether this was a dry run |
+
+---
+
+### WorkspaceMigrationResult
+
+Aggregate outcome of workspace-level migration.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `success` | `boolean` | True if all sessions migrated successfully |
+| `source` | `string` | Normalized source path |
+| `destination` | `string` | Normalized destination path |
+| `mode` | `'move' \| 'copy'` | The mode used |
+| `totalSessions` | `number` | Total sessions attempted |
+| `successCount` | `number` | Number of successful migrations |
+| `failureCount` | `number` | Number of failed migrations |
+| `results` | `SessionMigrationResult[]` | Per-session results |
+| `dryRun` | `boolean` | Whether this was a dry run |
+
+---
+
+### MigrationError
+
+Error details for a failed migration.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `code` | `string` | Error code (e.g., `SESSION_NOT_FOUND`, `WORKSPACE_NOT_FOUND`, `SQLITE_BUSY`) |
+| `message` | `string` | Human-readable error description |
+| `sessionId` | `string?` | The session that failed (if applicable) |
+| `details` | `Record<string, unknown>?` | Additional error context |
+
+**Error Codes**:
+- `SESSION_NOT_FOUND` - Session ID/index doesn't exist
+- `WORKSPACE_NOT_FOUND` - Destination path has no workspace directory
+- `SAME_WORKSPACE` - Source and destination are the same
+- `DATABASE_LOCKED` - Cursor is running
+- `PERMISSION_DENIED` - Cannot write to database files
+- `MIGRATION_FAILED` - Generic failure with details
+
+---
+
+## State Transitions
+
+### Session Migration Flow
+
+```
+┌─────────────┐
+│   IDLE      │
+└──────┬──────┘
+       │ migrateSession()
+       ▼
+┌─────────────┐     session not found
+│  RESOLVING  │─────────────────────────► ERROR (SESSION_NOT_FOUND)
+│  (ID/index) │
+└──────┬──────┘
+       │ session found
+       ▼
+┌─────────────┐     workspace not found
+│  VALIDATING │─────────────────────────► ERROR (WORKSPACE_NOT_FOUND)
+│  (dest path)│
+└──────┬──────┘
+       │ validation passes
+       ▼
+┌─────────────┐     dryRun=true
+│  PLANNING   │─────────────────────────► COMPLETE (dryRun result)
+└──────┬──────┘
+       │ dryRun=false
+       ▼
+┌─────────────┐
+│  UPDATING   │     write fails
+│  (global DB)│─────────────────────────► ERROR (MIGRATION_FAILED)
+└──────┬──────┘
+       │ global update success
+       ▼
+┌─────────────┐
+│  UPDATING   │     write fails
+│ (workspace) │─────────────────────────► PARTIAL_FAILURE
+└──────┬──────┘
+       │ all writes succeed
+       ▼
+┌─────────────┐
+│  COMPLETE   │
+└─────────────┘
+```
+
+### Workspace Migration Flow
+
+```
+┌─────────────┐
+│   IDLE      │
+└──────┬──────┘
+       │ migrateWorkspace()
+       ▼
+┌─────────────┐     no sessions found
+│  LISTING    │─────────────────────────► ERROR (NO_SESSIONS_FOUND)
+│  (sessions) │
+└──────┬──────┘
+       │ sessions found (n)
+       ▼
+┌─────────────┐
+│  ITERATING  │◄────────────────────┐
+│  (1 to n)   │                     │
+└──────┬──────┘                     │
+       │ migrateSession()           │
+       ▼                            │
+┌─────────────┐                     │
+│  RECORDING  │─────────────────────┘
+│  (result)   │     more sessions
+└──────┬──────┘
+       │ no more sessions
+       ▼
+┌─────────────┐
+│  COMPLETE   │ (aggregate results)
+└─────────────┘
+```
+
+---
+
+## Storage Schema
+
+### Key Insight: Workspace Association
+
+The workspace path is **NOT stored in the session data**. Instead, sessions are associated with workspaces by virtue of being stored in that workspace's `state.vscdb` file:
+
+```
+workspaceStorage/
+├── abc123/                    # Workspace directory (hash of path)
+│   ├── workspace.json         # {"folder": "file:///project-a"} ← defines the path
+│   └── state.vscdb            # Sessions here belong to project-a
+│       └── ItemTable
+│           └── composer.composerData: [session1, session2, ...]  ← JSON array
+```
+
+**Migration = moving session objects between JSON arrays in different workspace DBs**
+
+### Workspace Storage (`workspaceStorage/<hash>/state.vscdb`)
+
+**Table**: `ItemTable`
+
+| Key | Value Type | Description |
+|-----|------------|-------------|
+| `composer.composerData` | JSON array | Array of session objects for this workspace |
+
+**Migration operations**:
+- **Move**: Remove session from source array, add to destination array
+- **Copy**: Add session (with new ID) to destination array, keep in source
+
+**Session object structure** (within the array):
+```json
+{
+  "composerId": "abc123-def456",
+  "name": "Session title",
+  "createdAt": 1735034400000,
+  "richText": [...],
+  "bubbles": [...],
+  ...
+}
+```
+
+### Global Storage (`globalStorage/state.vscdb`)
+
+**Table**: `cursorDiskKV`
+
+| Key Pattern | Value | Migration Update |
+|-------------|-------|------------------|
+| `composerData:<sessionId>` | JSON with session metadata | Optional: update `workspaceUri` field |
+| `bubbleId:<sessionId>:<bubbleId>` | JSON with message data | No change needed (move), Copy for copy mode |
+
+**Note**: The `workspaceUri` in global storage is **display metadata only**. The authoritative workspace association is which `state.vscdb` contains the session. Updating `workspaceUri` is optional but recommended for consistency.
+
+---
+
+## Relationships
+
+```
+┌───────────────────────────────────────────────────────────────────┐
+│                     Migration Operation                           │
+│                                                                   │
+│  migrateSession(sessionId, destination)                          │
+│        │                                                          │
+│        │  1. Find source workspace containing session             │
+│        ▼                                                          │
+│  ┌─────────────────────────────────────────────────────────────┐ │
+│  │ Source Workspace DB (state.vscdb)                           │ │
+│  │ ItemTable.composer.composerData = [s1, s2, SESSION, s4]     │ │
+│  │                                                              │ │
+│  │ → Parse JSON array                                           │ │
+│  │ → Find SESSION by composerId                                 │ │
+│  │ → Remove from array (for move)                               │ │
+│  │ → Write updated array back                                   │ │
+│  └─────────────────────────────────────────────────────────────┘ │
+│        │                                                          │
+│        │  2. Add to destination workspace                         │
+│        ▼                                                          │
+│  ┌─────────────────────────────────────────────────────────────┐ │
+│  │ Dest Workspace DB (state.vscdb)                             │ │
+│  │ ItemTable.composer.composerData = [x1, x2]                  │ │
+│  │                                                              │ │
+│  │ → Parse JSON array                                           │ │
+│  │ → Append SESSION to array                                    │ │
+│  │ → Write updated array back                                   │ │
+│  │                                                              │ │
+│  │ Result: [x1, x2, SESSION]                                   │ │
+│  └─────────────────────────────────────────────────────────────┘ │
+│        │                                                          │
+│        │  3. (Optional) Update global metadata                    │
+│        ▼                                                          │
+│  ┌─────────────────────────────────────────────────────────────┐ │
+│  │ Global Storage (globalStorage/state.vscdb)                  │ │
+│  │ cursorDiskKV.composerData:<sessionId>.workspaceUri          │ │
+│  │                                                              │ │
+│  │ → Update workspaceUri to destination path                   │ │
+│  └─────────────────────────────────────────────────────────────┘ │
+│                                                                   │
+│  migrateWorkspace(source, destination)                           │
+│        │                                                          │
+│        └─────────► for each session in source:                   │
+│                      migrateSession(session.id, destination)     │
+└───────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Index Resolution
+
+| Input | Type | Resolution |
+|-------|------|------------|
+| `1` | number | Index 1 → lookup in `listSessions()` → session ID |
+| `3,5,7` | string | Parse as comma-separated indices → resolve each |
+| `abc123-def456` | string | Direct session UUID |
+| `abc123,def456` | string | Parse as comma-separated UUIDs |
+
+**Resolution function**:
+```typescript
+function resolveSessionIdentifiers(input: string): string[] {
+  const parts = input.split(',').map(s => s.trim());
+  return parts.map(part => {
+    if (/^\d+$/.test(part)) {
+      // Numeric: treat as index
+      const sessions = listSessions({ all: true });
+      const session = sessions.find(s => s.index === parseInt(part));
+      if (!session) throw new SessionNotFoundError(part);
+      return session.id;
+    }
+    // Non-numeric: treat as UUID
+    return part;
+  });
+}
+```

--- a/specs/003-migrate-workspace/plan.md
+++ b/specs/003-migrate-workspace/plan.md
@@ -1,0 +1,127 @@
+# Implementation Plan: Migrate Workspace History
+
+**Branch**: `003-migrate-workspace` | **Date**: 2025-12-24 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/003-migrate-workspace/spec.md`
+
+## Summary
+
+Add session-level and workspace-level migration commands to cursor-history. The core primitive is `migrate-session` which moves/copies individual sessions by ID to a destination workspace path. The `migrate` command is a convenience wrapper that migrates all sessions from a source path using migrate-session internally. This layered design reduces redundancy and enables fine-grained control.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.9+ (strict mode enabled)
+**Primary Dependencies**: better-sqlite3, commander, picocolors, node:fs (for workspace.json writes)
+**Storage**:
+- Workspace storage (`workspaceStorage/*/state.vscdb`) - session data in `ItemTable`
+- Global storage (`globalStorage/state.vscdb`) - full AI responses in `cursorDiskKV`
+- Workspace mapping (`workspace.json`) - folder path association
+**Testing**: Vitest for unit/integration tests
+**Target Platform**: Node.js 20+, cross-platform (Windows, macOS, Linux)
+**Project Type**: Single project (CLI + library)
+**Performance Goals**: Migration of 100 sessions within 10 seconds (per SC-010)
+**Constraints**: Must close Cursor before migration (database lock), preserve all session data
+**Scale/Scope**: Typical workspace has 1-50 sessions; rare cases may have 100+
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Simplicity First | ✅ Pass | Single core function (migrateSession), wrapper for bulk. Direct file/DB operations. |
+| II. CLI-Native Design | ✅ Pass | Two commands: `migrate-session <ids> <dest>` and `migrate <src> <dest>`. Standard flags. |
+| III. Documentation-Driven | ✅ Pass | Will document in README, help text with examples, error messages are actionable. |
+| IV. Incremental Delivery | ✅ Pass | P1: migrate-session (core). P1: migrate (uses core). P2: copy mode. P3: dry-run. |
+| V. Defensive Parsing | ✅ Pass | Validate session exists, paths differ, handle locked DB, report partial failures. |
+
+**Gate Status**: ✅ PASSED - No violations requiring justification.
+
+## Architecture
+
+### Layered Design
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                         CLI Layer                                │
+│  ┌─────────────────────┐    ┌─────────────────────────────────┐ │
+│  │  migrate-session    │    │         migrate                 │ │
+│  │  <ids> <dest>       │    │  <source> <destination>         │ │
+│  └──────────┬──────────┘    └───────────────┬─────────────────┘ │
+│             │                               │                    │
+│             │         ┌─────────────────────┘                    │
+│             │         │ (calls for each session)                 │
+│             ▼         ▼                                          │
+└─────────────────────────────────────────────────────────────────┘
+                        │
+                        ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                      Core Layer (src/core/)                      │
+│  ┌─────────────────────────────────────────────────────────────┐│
+│  │              migrateSession(options)                        ││
+│  │  - Resolves session ID/index                                ││
+│  │  - Updates workspace.json OR creates new workspace dir      ││
+│  │  - For copy: duplicates session data in ItemTable           ││
+│  └─────────────────────────────────────────────────────────────┘│
+└─────────────────────────────────────────────────────────────────┘
+                        │
+                        ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                    Library Layer (src/lib/)                      │
+│  ┌─────────────────────┐    ┌─────────────────────────────────┐ │
+│  │  migrateSession()   │    │  migrateWorkspace()             │ │
+│  │  (core primitive)   │    │  (uses migrateSession)          │ │
+│  └─────────────────────┘    └─────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/003-migrate-workspace/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   └── api.ts           # TypeScript interfaces
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── cli/
+│   ├── commands/
+│   │   ├── migrate-session.ts  # NEW: core migrate command (single/multiple sessions)
+│   │   ├── migrate.ts          # NEW: workspace-level migrate (uses migrate-session)
+│   │   ├── list.ts
+│   │   ├── show.ts
+│   │   ├── search.ts
+│   │   └── export.ts
+│   ├── formatters/
+│   └── index.ts                # Register both migrate commands
+├── core/
+│   ├── storage.ts              # ADD: migrateSession(), findWorkspaceForSession()
+│   ├── migrate.ts              # NEW: core migration logic (extracted for clarity)
+│   ├── parser.ts
+│   └── types.ts                # ADD: MigrateSessionOptions, MigrationResult
+└── lib/
+    ├── index.ts                # EXPORT: migrateSession(), migrateWorkspace()
+    ├── types.ts                # ADD: MigrateSessionConfig, MigrationResult
+    └── errors.ts               # ADD: SessionNotFoundError, MigrationError
+
+tests/
+├── unit/
+│   └── migrate.test.ts         # Unit tests for migration logic
+└── integration/
+    └── migrate.test.ts         # Integration tests with real DB fixtures
+```
+
+**Structure Decision**: Follows existing single project structure. Core migration logic in dedicated `migrate.ts` file (shared by both commands). Both CLI commands in separate files for clarity.
+
+## Complexity Tracking
+
+> No Constitution violations - table not needed.

--- a/specs/003-migrate-workspace/quickstart.md
+++ b/specs/003-migrate-workspace/quickstart.md
@@ -1,0 +1,173 @@
+# Quickstart: Migrate Workspace History
+
+## CLI Usage
+
+### Migrate Single Session
+
+```bash
+# Move session by index (from `cursor-history list`)
+cursor-history migrate-session 3 /path/to/new/project
+
+# Move session by ID
+cursor-history migrate-session abc123-def456 /path/to/new/project
+
+# Move multiple sessions
+cursor-history migrate-session 1,3,5 /path/to/new/project
+
+# Copy instead of move (keeps original)
+cursor-history migrate-session --copy 3 /path/to/new/project
+
+# Dry run (preview without changes)
+cursor-history migrate-session --dry-run 3 /path/to/new/project
+```
+
+### Migrate All Sessions from Workspace
+
+```bash
+# Move all sessions from old project to new
+cursor-history migrate /old/project/path /new/project/path
+
+# Copy all sessions (create backup)
+cursor-history migrate --copy /project/path /backup/project/path
+
+# Force migration if destination already has sessions
+cursor-history migrate --force /old/path /existing/path
+
+# Dry run to see what would be migrated
+cursor-history migrate --dry-run /old/path /new/path
+```
+
+### Common Workflow: Project Rename
+
+```bash
+# 1. Rename your project folder
+mv ~/projects/my-app ~/projects/my-app-v2
+
+# 2. Open the new folder in Cursor (creates workspace)
+# (This step is required so the destination workspace exists)
+
+# 3. Migrate all chat history
+cursor-history migrate ~/projects/my-app ~/projects/my-app-v2
+
+# 4. Verify migration
+cursor-history list --workspace ~/projects/my-app-v2
+```
+
+## Library Usage
+
+### Migrate Sessions Programmatically
+
+```typescript
+import {
+  migrateSession,
+  migrateWorkspace,
+  isSessionNotFoundError,
+  isWorkspaceNotFoundError
+} from 'cursor-history';
+
+// Move a single session by index
+const result = migrateSession({
+  sessions: 3,
+  destination: '/path/to/new/project'
+});
+
+console.log(`Migrated: ${result[0].success}`);
+console.log(`From: ${result[0].sourceWorkspace}`);
+console.log(`To: ${result[0].destinationWorkspace}`);
+
+// Move multiple sessions
+const results = migrateSession({
+  sessions: [1, 3, 5],
+  destination: '/path/to/new/project'
+});
+
+const successful = results.filter(r => r.success).length;
+console.log(`Migrated ${successful}/${results.length} sessions`);
+```
+
+### Migrate Entire Workspace
+
+```typescript
+import { migrateWorkspace } from 'cursor-history';
+
+const result = migrateWorkspace({
+  source: '/old/project',
+  destination: '/new/project',
+  mode: 'move' // or 'copy'
+});
+
+if (result.success) {
+  console.log(`Migrated all ${result.totalSessions} sessions`);
+} else {
+  console.log(`Migrated ${result.successCount}/${result.totalSessions}`);
+  result.results
+    .filter(r => !r.success)
+    .forEach(r => console.error(`Failed: ${r.sessionId} - ${r.error?.message}`));
+}
+```
+
+### Error Handling
+
+```typescript
+import {
+  migrateSession,
+  isSessionNotFoundError,
+  isWorkspaceNotFoundError
+} from 'cursor-history';
+
+try {
+  const result = migrateSession({
+    sessions: 999, // Non-existent
+    destination: '/some/path'
+  });
+} catch (err) {
+  if (isSessionNotFoundError(err)) {
+    console.error(`Session ${err.identifier} not found`);
+    console.error('Run `cursor-history list` to see available sessions');
+  } else if (isWorkspaceNotFoundError(err)) {
+    console.error(`Workspace not found: ${err.path}`);
+    console.error('Please open the project in Cursor first');
+  } else {
+    throw err;
+  }
+}
+```
+
+### Dry Run Preview
+
+```typescript
+import { migrateWorkspace } from 'cursor-history';
+
+// Preview what would be migrated
+const preview = migrateWorkspace({
+  source: '/old/project',
+  destination: '/new/project',
+  dryRun: true
+});
+
+console.log(`Would migrate ${preview.totalSessions} sessions:`);
+preview.results.forEach(r => {
+  console.log(`  - ${r.sessionId}`);
+});
+
+// Actually perform migration if user confirms
+if (userConfirms()) {
+  const result = migrateWorkspace({
+    source: '/old/project',
+    destination: '/new/project',
+    dryRun: false
+  });
+}
+```
+
+## Important Notes
+
+1. **Close Cursor first**: Migration modifies Cursor's internal database. Close Cursor before running migration commands to avoid database lock errors.
+
+2. **Destination must exist**: The destination workspace must have been opened in Cursor at least once. This creates the necessary workspace directory structure.
+
+3. **Move is default**: Without `--copy`, sessions are moved (removed from source). Use `--copy` to keep originals.
+
+4. **Partial failure continues**: If some sessions fail to migrate, the command continues with remaining sessions and reports per-session results.
+
+5. **Use dry-run first**: For important migrations, use `--dry-run` to preview what will happen before making changes.

--- a/specs/003-migrate-workspace/research.md
+++ b/specs/003-migrate-workspace/research.md
@@ -1,0 +1,251 @@
+# Research: Migrate Workspace History
+
+**Feature**: 003-migrate-workspace
+**Date**: 2025-12-24
+**Updated**: 2025-12-24 (revised for session-level architecture)
+
+## Research Questions
+
+### 1. How are sessions stored and associated with workspaces?
+
+**Decision**: The authoritative workspace association is determined by WHICH workspace's `state.vscdb` contains the session.
+
+**Findings**:
+
+#### Key Insight: Workspace Association
+The workspace path is NOT stored in the session data itself. Instead:
+- Each workspace directory has its own `state.vscdb` containing sessions
+- The `workspace.json` file maps the directory to a project folder path
+- When listing sessions, the code assigns `workspacePath` from the workspace's `workspace.json`, not from session fields
+
+```
+workspaceStorage/
+├── abc123/                    # Workspace dir (hash of path)
+│   ├── workspace.json         # {"folder": "file:///project-a"}
+│   └── state.vscdb            # Sessions here belong to project-a
+├── def456/
+│   ├── workspace.json         # {"folder": "file:///project-b"}
+│   └── state.vscdb            # Sessions here belong to project-b
+```
+
+#### Workspace Storage (`workspaceStorage/<hash>/state.vscdb`)
+- Sessions stored in `ItemTable` under key `composer.composerData`
+- Value is a **JSON array** of session objects (not individual rows per session)
+- The workspace association is implicit: if session is in this file, it belongs to this workspace
+
+#### Global Storage (`globalStorage/state.vscdb`)
+- Full conversation data in `cursorDiskKV` table
+- Keys: `composerData:<sessionId>` (metadata), `bubbleId:<sessionId>:<bubbleId>` (messages)
+- Contains `workspaceUri` field - this is optional display metadata, NOT the authoritative source
+
+**Session Migration Approach**:
+1. **Move**: Remove session from source workspace's JSON array, add to destination's JSON array
+2. **Copy**: Add session (with new ID) to destination's JSON array, keep original
+3. **Optional**: Update `workspaceUri` in global storage for consistency (not required for migration to work)
+
+### 2. How to migrate a single session by ID?
+
+**Decision**: Modify workspace storage JSON arrays (primary), optionally update global metadata.
+
+**Implementation Steps**:
+
+```typescript
+function migrateSession(options: MigrateSessionOptions): MigrationResult {
+  // 1. Resolve session ID from index if needed
+  const sessionId = resolveSessionId(options.sessionIdOrIndex);
+
+  // 2. Find source workspace containing this session
+  const sourceWorkspace = findWorkspaceForSession(sessionId);
+  if (!sourceWorkspace) throw new SessionNotFoundError(sessionId);
+
+  // 3. Find destination workspace by path
+  const destWorkspace = findWorkspaceByPath(options.destination);
+  if (!destWorkspace) throw new WorkspaceNotFoundError(options.destination);
+
+  // 4. Read source workspace's composer.composerData JSON array
+  const sourceDb = openDatabaseReadWrite(sourceWorkspace.dbPath);
+  const sourceData = getComposerData(sourceDb); // JSON array of sessions
+
+  // 5. Find and extract the session object from source array
+  const sessionIndex = sourceData.findIndex(s => s.composerId === sessionId);
+  const sessionObj = sourceData[sessionIndex];
+
+  // 6. Remove from source (for move) or keep (for copy)
+  if (options.mode === 'move') {
+    sourceData.splice(sessionIndex, 1);
+    updateComposerData(sourceDb, sourceData);
+  }
+  sourceDb.close();
+
+  // 7. Add to destination workspace's composer.composerData
+  const destDb = openDatabaseReadWrite(destWorkspace.dbPath);
+  const destData = getComposerData(destDb);
+  destData.push(sessionObj); // or copy with new ID for copy mode
+  updateComposerData(destDb, destData);
+  destDb.close();
+
+  // 8. (Optional) Update workspaceUri in global storage for consistency
+  updateGlobalWorkspaceUri(sessionId, options.destination);
+
+  return { success: true, sessionId, ... };
+}
+```
+
+**Key insight**: The migration is essentially:
+1. Parse JSON array from source DB
+2. Remove session object from array (move) or keep it (copy)
+3. Parse JSON array from destination DB
+4. Add session object to that array
+5. Write both arrays back
+
+### 3. How to find or create a workspace for a destination path?
+
+**Decision**: Check existing workspaces first, create new if needed.
+
+**Findings**:
+
+The workspace hash directory name is derived from the folder path. Cursor uses a specific hashing algorithm.
+
+**For existing workspaces**:
+```typescript
+function findWorkspaceByPath(folderPath: string): Workspace | null {
+  const workspaces = findWorkspaces();
+  return workspaces.find(w => w.path === folderPath) ?? null;
+}
+```
+
+**For new workspaces** (destination path has no existing workspace):
+1. Cannot easily create new workspace hash (Cursor's algorithm is internal)
+2. Alternative: Reuse an existing empty workspace or wait for Cursor to create it
+3. **Simplest approach**: Require destination workspace to exist (user must have opened the project in Cursor at least once)
+
+**Recommendation**: For MVP, require destination workspace to already exist. Document this limitation. Future enhancement could handle workspace creation.
+
+### 4. What database operations are needed?
+
+**Decision**: Read-write access to both global and workspace SQLite databases.
+
+**Operations needed**:
+
+#### Global Storage (`globalStorage/state.vscdb`)
+```sql
+-- Update session metadata with new workspaceUri
+UPDATE cursorDiskKV
+SET value = json_set(value, '$.workspaceUri', 'file:///new/path')
+WHERE key = 'composerData:<sessionId>';
+```
+
+#### Workspace Storage - Source (`workspaceStorage/<srcHash>/state.vscdb`)
+```sql
+-- For MOVE: Remove session from source
+-- Need to parse JSON, remove session, rewrite
+UPDATE ItemTable
+SET value = <updated_json_without_session>
+WHERE key = 'composer.composerData';
+```
+
+#### Workspace Storage - Destination (`workspaceStorage/<destHash>/state.vscdb`)
+```sql
+-- Add session to destination
+-- Need to parse JSON, add session, rewrite
+UPDATE ItemTable
+SET value = <updated_json_with_session>
+WHERE key = 'composer.composerData';
+```
+
+**Note**: Session data is stored as JSON arrays, so updates require parse → modify → serialize → write.
+
+### 5. How to handle copy mode?
+
+**Decision**: For copy, duplicate the session with a new unique ID.
+
+**Implementation**:
+1. Generate new UUID for the copied session
+2. Copy all bubble data in global storage with new keys: `bubbleId:<newId>:<bubbleId>`
+3. Copy composerData with new ID to global storage
+4. Add session to destination workspace's `composer.composerData` JSON
+
+**Complexity note**: Copy is more complex than move because:
+- Must generate new unique session ID
+- Must duplicate all bubble entries (could be many per session)
+- Must update internal references within the copied data
+
+**Recommendation**: Implement move first (P1), copy as P2.
+
+### 6. Validation and error handling
+
+**Decision**: Fail fast with clear error messages.
+
+**Validations**:
+1. Session ID/index must resolve to existing session
+2. Destination path must have an existing workspace (for MVP)
+3. Database must not be locked (SQLITE_BUSY check)
+4. Source and destination must differ
+
+**Error types**:
+- `SessionNotFoundError` - session ID/index doesn't exist
+- `WorkspaceNotFoundError` - destination path has no workspace
+- `DatabaseLockedError` - Cursor is running
+- `MigrationError` - generic migration failure with details
+
+### 7. How does migrateWorkspace use migrateSession?
+
+**Decision**: Simple loop with result aggregation.
+
+**Implementation**:
+```typescript
+function migrateWorkspace(options: MigrateWorkspaceOptions): MigrationResult[] {
+  // 1. Find all sessions in source workspace
+  const sessions = listSessions({ workspacePath: options.source });
+
+  if (sessions.length === 0) {
+    throw new NoSessionsFoundError(options.source);
+  }
+
+  // 2. Migrate each session
+  const results: MigrationResult[] = [];
+  for (const session of sessions) {
+    try {
+      const result = migrateSession({
+        sessionId: session.id,
+        destination: options.destination,
+        mode: options.mode,
+        dryRun: options.dryRun,
+        force: options.force,
+      });
+      results.push(result);
+    } catch (err) {
+      results.push({ success: false, sessionId: session.id, error: err });
+      // Continue with remaining sessions (no rollback)
+    }
+  }
+
+  return results;
+}
+```
+
+## Summary
+
+| Topic | Decision | Rationale |
+|-------|----------|-----------|
+| Core primitive | `migrateSession()` | Single session migration, all other operations build on this |
+| Storage updates | Global + workspace DBs | Both need updates for complete migration |
+| Workspace creation | Require existing | Cursor's hash algorithm is internal; user must open project first |
+| Move operation | Update references, move data | Simple, no duplication needed |
+| Copy operation | Duplicate with new IDs | More complex, defer to P2 |
+| Error handling | Continue on partial failure | Report per-session results, don't rollback successes |
+| migrateWorkspace | Loop over migrateSession | Reduces redundancy, consistent behavior |
+
+## Implementation Notes
+
+1. **Read-write DB access**: Add `openDatabaseReadWrite()` function
+2. **JSON manipulation**: Parse, modify, serialize session arrays in ItemTable
+3. **Transaction safety**: Use SQLite transactions for atomic updates per session
+4. **Index resolution**: Reuse existing `listSessions()` to map index → session ID
+5. **Path normalization**: Consistent handling of paths before comparison/storage
+
+## Open Questions Resolved
+
+1. ~~Should we support wildcard/glob source paths?~~ No, exact match per clarification
+2. ~~Should we backup before modifying?~~ Yes, create `.bak` files (implementation detail)
+3. ~~What if destination has sessions?~~ Handled by `--force` (additive merge)

--- a/specs/003-migrate-workspace/spec.md
+++ b/specs/003-migrate-workspace/spec.md
@@ -1,0 +1,192 @@
+# Feature Specification: Migrate Workspace History
+
+**Feature Branch**: `003-migrate-workspace`
+**Created**: 2025-12-24
+**Status**: Draft
+**Input**: User description: "CLI command and library API to move/copy chat history from one workspace directory to another, enabling history migration after project renames. Two modes: copy (like cp) and move (like mv). Support fine-grained session-level migration."
+
+## Clarifications
+
+### Session 2025-12-24
+
+- Q: How should the system match the source workspace path to sessions in the database? → A: Exact match only - only migrate sessions where stored path exactly equals the source path.
+- Q: When `--force` is used and destination already has history, what happens to existing sessions? → A: Additive merge - keep existing destination sessions, add migrated sessions alongside them.
+- Q: How should session-level migration work with the CLI interface? → A: Separate command - `migrate-session` for individual sessions, `migrate` for workspace-level (which uses migrate-session internally).
+
+## Architecture Overview
+
+The migration feature has a **layered design**:
+
+1. **Core primitive**: `migrate-session` - moves/copies a single session by ID to a destination path
+2. **Convenience wrapper**: `migrate` - migrates all sessions from a source path to destination (calls migrate-session for each)
+
+This design reduces redundancy and allows fine-grained control when needed.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Migrate Single Session to New Project (Priority: P1)
+
+A developer wants to move a specific chat conversation from one project to another. For example, they started a conversation in project A but realized it belongs in project B.
+
+**Why this priority**: Fine-grained session migration is the core primitive. All other operations build on this.
+
+**Independent Test**: Can be fully tested by running `cursor-history migrate-session <session-id> /dest/path` and verifying the session appears under the new workspace.
+
+**Acceptance Scenarios**:
+
+1. **Given** a session with ID `abc123` associated with `/home/user/project-a`, **When** user runs `cursor-history migrate-session abc123 /home/user/project-b`, **Then** the session is now associated with `/home/user/project-b` and no longer appears under `/home/user/project-a`.
+
+2. **Given** a session ID that doesn't exist, **When** user runs `migrate-session`, **Then** the system displays an error message indicating session not found.
+
+3. **Given** a session index (e.g., `3`) instead of ID, **When** user runs `cursor-history migrate-session 3 /dest/path`, **Then** the system resolves the index to the session ID and migrates it.
+
+---
+
+### User Story 2 - Migrate Multiple Sessions by ID (Priority: P1)
+
+A developer wants to move several specific sessions at once without migrating the entire workspace.
+
+**Why this priority**: Common use case when reorganizing history across projects.
+
+**Independent Test**: Can be fully tested by running `cursor-history migrate-session 1,3,5 /dest/path` and verifying all specified sessions move.
+
+**Acceptance Scenarios**:
+
+1. **Given** sessions with indices 1, 3, and 5, **When** user runs `cursor-history migrate-session 1,3,5 /home/user/new-project`, **Then** all three sessions are migrated to the new path.
+
+2. **Given** a list containing a non-existent session ID, **When** user runs migrate-session, **Then** the system reports which sessions succeeded and which failed, without rolling back successful migrations.
+
+---
+
+### User Story 3 - Move All History to Renamed Project (Priority: P1)
+
+A developer has renamed their project directory and wants to move all chat history to the new path.
+
+**Why this priority**: Most common bulk operation - project renames happen frequently.
+
+**Independent Test**: Can be fully tested by running `cursor-history migrate /old/path /new/path` and verifying all history moves.
+
+**Acceptance Scenarios**:
+
+1. **Given** a workspace with 10 chat sessions at `/home/user/old-project`, **When** user runs `cursor-history migrate /home/user/old-project /home/user/new-project`, **Then** all 10 sessions are now associated with the new path (internally calls migrate-session for each).
+
+2. **Given** a source path with no chat history, **When** user runs the migrate command, **Then** the system displays an error message indicating no sessions found for the source path.
+
+3. **Given** a successful move operation, **When** user runs `cursor-history list --workspace /home/user/new-project`, **Then** all migrated sessions appear in the list.
+
+---
+
+### User Story 4 - Copy Sessions to New Location (Priority: P2)
+
+A developer wants to duplicate specific sessions or all sessions to a new workspace path while keeping the originals intact.
+
+**Why this priority**: Copy operation is less common than move but useful for forking projects or creating backups.
+
+**Independent Test**: Can be fully tested by running `cursor-history migrate-session --copy <id> /dest/path` or `cursor-history migrate --copy /src /dest`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a session with ID `abc123`, **When** user runs `cursor-history migrate-session --copy abc123 /home/user/project-b`, **Then** the session exists at both the original location and the new path.
+
+2. **Given** `cursor-history migrate --copy /src /dest`, **When** operation completes, **Then** sessions exist at both source and destination paths.
+
+---
+
+### User Story 5 - Programmatic Migration via Library API (Priority: P2)
+
+A developer building tooling around Cursor wants to programmatically migrate sessions as part of their automation workflow.
+
+**Why this priority**: Library API enables integration with other tools and automation scripts.
+
+**Independent Test**: Can be fully tested by calling `migrateSession()` and `migrateWorkspace()` functions.
+
+**Acceptance Scenarios**:
+
+1. **Given** the library is imported, **When** developer calls `migrateSession({ sessionId: 'abc123', destination: '/new/path', mode: 'move' })`, **Then** the function returns a result object with migration status.
+
+2. **Given** the library is imported, **When** developer calls `migrateWorkspace({ source: '/old/path', destination: '/new/path', mode: 'move' })`, **Then** the function internally calls migrateSession for each matching session and returns aggregate results.
+
+3. **Given** an invalid session ID, **When** developer calls migrateSession, **Then** the function throws a `SessionNotFoundError`.
+
+---
+
+### User Story 6 - Dry Run Preview (Priority: P3)
+
+A user wants to preview what will be migrated before actually performing the operation.
+
+**Why this priority**: Safety feature that helps users avoid mistakes.
+
+**Independent Test**: Can be fully tested by adding `--dry-run` flag to any migrate command.
+
+**Acceptance Scenarios**:
+
+1. **Given** any migrate command with `--dry-run`, **When** executed, **Then** output shows what would happen without making any changes.
+
+2. **Given** `cursor-history migrate --dry-run /old/path /new/path`, **When** output is displayed, **Then** it lists each session that would be migrated with its ID and title.
+
+---
+
+### Edge Cases
+
+- What happens when the destination path already has existing chat history? System should warn and require `--force` flag to proceed; with `--force`, performs additive merge.
+- What happens when source and destination paths are the same? System should display an error indicating paths must be different.
+- What happens when a session ID is provided both as index and UUID format? System should try index first (if numeric), then UUID.
+- What happens during a partial failure in bulk migration? System should report which sessions succeeded/failed and continue with remaining sessions.
+- What happens if the database is locked by Cursor? System should display the existing "database locked" error with guidance to close Cursor.
+- What happens when migrating to a workspace that doesn't have a workspace directory yet? System should create the necessary workspace directory structure.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Core (Session-Level)
+- **FR-001**: System MUST support `migrate-session` command that moves/copies individual sessions by ID or index.
+- **FR-002**: System MUST accept multiple session identifiers (comma-separated) in a single migrate-session call.
+- **FR-003**: System MUST resolve session index to session ID before migration.
+- **FR-004**: System MUST support two modes for session migration: `move` (default) and `copy`.
+
+#### Workspace-Level (Built on Core)
+- **FR-005**: System MUST support `migrate` command that migrates all sessions from source path to destination.
+- **FR-006**: `migrate` command MUST internally use session-level migration for each matching session.
+- **FR-007**: System MUST use exact path matching when identifying sessions to migrate (no prefix or fuzzy matching).
+
+#### Common
+- **FR-008**: System MUST provide a dry-run option (`--dry-run`) for both commands.
+- **FR-009**: System MUST report results: sessions affected, success/failure status per session.
+- **FR-010**: System MUST require `--force` flag when destination already has history; when forced, perform additive merge.
+- **FR-011**: System MUST support both absolute and relative paths (relative paths resolved to absolute).
+- **FR-012**: System MUST preserve all session data during migration (messages, timestamps, metadata).
+
+#### Library API
+- **FR-013**: Library MUST expose `migrateSession(options)` function as the core primitive.
+- **FR-014**: Library MUST expose `migrateWorkspace(options)` function that uses migrateSession internally.
+- **FR-015**: Library functions MUST return typed result objects with migration details.
+
+### Key Entities
+
+- **Session ID**: Unique identifier for a chat session (UUID format like `abc123-def456`).
+- **Session Index**: 1-based position in the session list (as shown by `cursor-history list`).
+- **Workspace Path**: The directory path associated with a chat session.
+- **Migration Result**: Outcome including session ID, source/destination paths, mode, success status, and any errors.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can migrate a single session by ID or index in one command.
+- **SC-002**: Users can migrate multiple sessions by providing comma-separated IDs/indices.
+- **SC-003**: Users can migrate all sessions from a workspace in one command.
+- **SC-004**: `migrate` command produces identical results to running `migrate-session` for each session individually.
+- **SC-005**: Migrated sessions appear correctly in Cursor's chat history view under the new workspace path.
+- **SC-006**: Move operations remove the session from the original workspace.
+- **SC-007**: Copy operations preserve the session at the original workspace.
+- **SC-008**: Dry-run operations make zero modifications to the database.
+- **SC-009**: Library API provides equivalent functionality to CLI with programmatic error handling.
+- **SC-010**: Migration of 100 sessions completes within 10 seconds.
+
+## Assumptions
+
+- Session IDs are globally unique across all workspaces.
+- The existing `list` command provides session indices that can be used with migrate-session.
+- Users understand that this tool modifies Cursor's internal database and should close Cursor before running.
+- For copy operations, the system can create new session entries with the same content but associated with a different workspace path.

--- a/specs/003-migrate-workspace/tasks.md
+++ b/specs/003-migrate-workspace/tasks.md
@@ -1,0 +1,255 @@
+# Tasks: Migrate Workspace History
+
+**Input**: Design documents from `/specs/003-migrate-workspace/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/api.ts
+
+**Tests**: Not explicitly requested in spec. Test tasks omitted.
+
+**Organization**: Tasks grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, etc.)
+- Paths are relative to repository root
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Project initialization and type definitions
+
+- [x] T001 Add migration types to src/core/types.ts (MigrateSessionOptions, SessionMigrationResult, MigrationMode)
+- [x] T002 [P] Add migration error classes to src/lib/errors.ts (SessionNotFoundError, WorkspaceNotFoundError, SameWorkspaceError)
+- [x] T003 [P] Add migration types to src/lib/types.ts (MigrateSessionConfig, MigrationResult for library API)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core infrastructure that MUST be complete before ANY user story can be implemented
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [x] T004 Add openDatabaseReadWrite() function to src/core/storage.ts (readonly: false option)
+- [x] T005 Add findWorkspaceForSession(sessionId) function to src/core/storage.ts
+- [x] T006 Add findWorkspaceByPath(path) function to src/core/storage.ts
+- [x] T007 Add getComposerData(db) function to src/core/storage.ts (read JSON array from ItemTable)
+- [x] T008 Add updateComposerData(db, data) function to src/core/storage.ts (write JSON array to ItemTable)
+- [x] T009 Add resolveSessionIdentifiers(input) function to src/core/storage.ts (index/ID resolution)
+- [x] T010 Add path normalization utilities to src/lib/platform.ts (normalizePath, pathsEqual)
+
+**Checkpoint**: Foundation ready - user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 - Migrate Single Session (Priority: P1) 🎯 MVP
+
+**Goal**: Move a single session by ID or index to a new workspace path
+
+**Independent Test**: `cursor-history migrate-session <session-id> /dest/path` moves one session
+
+### Implementation for User Story 1
+
+- [x] T011 [US1] Create core migrateSession() function in src/core/migrate.ts (move mode only)
+- [x] T012 [US1] Implement session extraction from source workspace JSON array in src/core/migrate.ts
+- [x] T013 [US1] Implement session insertion into destination workspace JSON array in src/core/migrate.ts
+- [x] T014 [US1] N/A - workspaceUri in global storage is informational only; bubble data referenced by composerId
+- [x] T015 [US1] Create migrate-session CLI command in src/cli/commands/migrate-session.ts
+- [x] T016 [US1] Register migrate-session command in src/cli/index.ts
+- [x] T017 [US1] Add validation: session exists, destination workspace exists, paths differ in src/core/migrate.ts
+- [x] T018 [US1] Add error handling and user-friendly messages in src/cli/commands/migrate-session.ts
+
+**Checkpoint**: Single session migration (move mode) works via CLI
+
+---
+
+## Phase 4: User Story 2 - Migrate Multiple Sessions (Priority: P1)
+
+**Goal**: Move multiple sessions by comma-separated IDs/indices in one command
+
+**Independent Test**: `cursor-history migrate-session 1,3,5 /dest/path` moves all three sessions
+
+### Implementation for User Story 2
+
+- [x] T019 [US2] Update migrate-session command to accept comma-separated identifiers in src/cli/commands/migrate-session.ts
+- [x] T020 [US2] Implement batch migration loop in src/core/migrate.ts (call single-session for each)
+- [x] T021 [US2] Add per-session result reporting (success/failure) in src/cli/commands/migrate-session.ts
+- [x] T022 [US2] Handle partial failures: continue with remaining sessions, report all results in src/core/migrate.ts
+
+**Checkpoint**: Multiple session migration works via CLI
+
+---
+
+## Phase 5: User Story 3 - Move All History (Workspace-Level) (Priority: P1)
+
+**Goal**: Move all sessions from source workspace path to destination in one command
+
+**Independent Test**: `cursor-history migrate /old/path /new/path` moves all sessions from old to new
+
+### Implementation for User Story 3
+
+- [x] T023 [US3] Create migrateWorkspace() function in src/core/migrate.ts (uses migrateSession internally)
+- [x] T024 [US3] Implement session listing for source workspace path (exact match) in src/core/migrate.ts
+- [x] T025 [US3] Create migrate CLI command in src/cli/commands/migrate.ts
+- [x] T026 [US3] Register migrate command in src/cli/index.ts
+- [x] T027 [US3] Add validation: source has sessions, destination workspace exists in src/core/migrate.ts
+- [x] T028 [US3] Add aggregate result reporting in src/cli/commands/migrate.ts
+- [x] T029 [US3] Handle --force flag for destination with existing history in src/cli/commands/migrate.ts
+
+**Checkpoint**: Workspace-level migration works via CLI
+
+---
+
+## Phase 6: User Story 4 - Copy Sessions (Priority: P2)
+
+**Goal**: Duplicate sessions to new workspace while keeping originals (--copy flag)
+
+**Independent Test**: `cursor-history migrate-session --copy <id> /dest` keeps original and creates copy
+
+### Implementation for User Story 4
+
+- [x] T030 [US4] Add --copy flag to migrate-session command in src/cli/commands/migrate-session.ts
+- [x] T031 [US4] Implement copy mode in migrateSession(): generate new session ID in src/core/migrate.ts
+- [x] T032 [US4] Implement bubble data duplication in global storage for copy mode in src/core/migrate.ts
+- [x] T033 [US4] Update composerData duplication with new ID in src/core/migrate.ts
+- [x] T034 [US4] Add --copy flag to migrate command in src/cli/commands/migrate.ts
+- [x] T035 [US4] Return newSessionId in result for copy operations in src/core/migrate.ts
+
+**Checkpoint**: Copy mode works for both session and workspace migration
+
+---
+
+## Phase 7: User Story 5 - Library API (Priority: P2)
+
+**Goal**: Expose migration functions for programmatic use via library
+
+**Independent Test**: `import { migrateSession } from 'cursor-history'` works and returns typed results
+
+### Implementation for User Story 5
+
+- [x] T036 [P] [US5] Create library wrapper migrateSession() in src/lib/index.ts (uses core function)
+- [x] T037 [P] [US5] Create library wrapper migrateWorkspace() in src/lib/index.ts (uses core function)
+- [x] T038 [US5] Add type guards (isSessionNotFoundError, etc.) to src/lib/errors.ts
+- [x] T039 [US5] Export migration functions and types from src/lib/index.ts
+- [x] T040 [US5] Add JSDoc documentation with examples to library functions in src/lib/index.ts
+
+**Checkpoint**: Library API provides equivalent functionality to CLI
+
+---
+
+## Phase 8: User Story 6 - Dry Run Preview (Priority: P3)
+
+**Goal**: Preview migration without making changes (--dry-run flag)
+
+**Independent Test**: `cursor-history migrate --dry-run /old /new` shows what would happen, makes no changes
+
+### Implementation for User Story 6
+
+- [x] T041 [US6] Add --dry-run flag to migrate-session command in src/cli/commands/migrate-session.ts
+- [x] T042 [US6] Implement dryRun mode in migrateSession(): skip DB writes, return preview in src/core/migrate.ts
+- [x] T043 [US6] Add --dry-run flag to migrate command in src/cli/commands/migrate.ts
+- [x] T044 [US6] Format dry-run output: list sessions that would be migrated in src/cli/commands/migrate.ts
+- [x] T045 [US6] Ensure dryRun flag propagates through library API in src/lib/index.ts
+
+**Checkpoint**: Dry-run works for all migration commands
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, error messages, edge cases
+
+- [x] T046 [P] Update CLAUDE.md with migrate commands documentation
+- [x] T047 [P] Add help text with examples to migrate-session command in src/cli/commands/migrate-session.ts
+- [x] T048 [P] Add help text with examples to migrate command in src/cli/commands/migrate.ts
+- [x] T049 Verify error messages are actionable (close Cursor, check paths, etc.)
+- [ ] T050 Run quickstart.md validation scenarios manually
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - BLOCKS all user stories
+- **User Stories (Phase 3-8)**: All depend on Foundational phase completion
+  - US1 (P1): Core primitive, must complete first
+  - US2 (P1): Builds on US1
+  - US3 (P1): Builds on US1/US2
+  - US4 (P2): Builds on US1, can parallel with US5/US6
+  - US5 (P2): Builds on US1-US3
+  - US6 (P3): Builds on US1-US3
+- **Polish (Phase 9)**: Depends on all desired user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational - MVP core primitive
+- **User Story 2 (P1)**: Requires US1 - extends single to multiple
+- **User Story 3 (P1)**: Requires US1/US2 - workspace-level wrapper
+- **User Story 4 (P2)**: Requires US1 - adds copy mode
+- **User Story 5 (P2)**: Requires US1-US3 - library wrappers
+- **User Story 6 (P3)**: Requires US1-US3 - dry-run mode
+
+### Parallel Opportunities
+
+- T002, T003 can run in parallel (different files)
+- T036, T037 can run in parallel (different functions in same file)
+- T046, T047, T048 can run in parallel (documentation tasks)
+
+---
+
+## Parallel Example: Phase 1 Setup
+
+```bash
+# These can run in parallel (different files):
+Task: "Add migration error classes to src/lib/errors.ts"
+Task: "Add migration types to src/lib/types.ts"
+```
+
+## Parallel Example: Phase 7 Library API
+
+```bash
+# These can run in parallel (different functions):
+Task: "Create library wrapper migrateSession() in src/lib/index.ts"
+Task: "Create library wrapper migrateWorkspace() in src/lib/index.ts"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Stories 1-3 Only)
+
+1. Complete Phase 1: Setup (types and errors)
+2. Complete Phase 2: Foundational (DB helpers, path utilities)
+3. Complete Phase 3: User Story 1 (single session move)
+4. **STOP and VALIDATE**: Test `migrate-session 1 /new/path`
+5. Complete Phase 4: User Story 2 (multiple sessions)
+6. Complete Phase 5: User Story 3 (workspace migrate)
+7. **MVP COMPLETE**: Core migration functionality works
+
+### Incremental Delivery
+
+1. Setup + Foundational → Foundation ready
+2. Add US1 → Test single session → Demo
+3. Add US2 → Test multiple sessions → Demo
+4. Add US3 → Test workspace migrate → Demo (MVP!)
+5. Add US4 → Test copy mode → Demo
+6. Add US5 → Test library API → Demo
+7. Add US6 → Test dry-run → Demo
+8. Polish phase → Documentation complete
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story should be independently completable and testable
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently
+- Core migration logic in src/core/migrate.ts (shared by CLI and library)
+- CLI commands in separate files (migrate-session.ts, migrate.ts)
+- Library wrappers just call core functions with type conversions

--- a/src/cli/commands/migrate-session.ts
+++ b/src/cli/commands/migrate-session.ts
@@ -1,0 +1,159 @@
+/**
+ * CLI command for migrating individual sessions between workspaces
+ *
+ * Usage:
+ *   cursor-history migrate-session <session> <destination>
+ *   cursor-history migrate-session 3 /path/to/new/project
+ *   cursor-history migrate-session 1,3,5 /path/to/new/project
+ *   cursor-history migrate-session --dry-run 3 /path/to/new/project
+ */
+
+import { Command } from 'commander';
+import pc from 'picocolors';
+import { resolveSessionIdentifiers } from '../../core/storage.js';
+import { migrateSessions } from '../../core/migrate.js';
+import { expandPath } from '../../lib/platform.js';
+import {
+  isSessionNotFoundError,
+  isWorkspaceNotFoundError,
+  isSameWorkspaceError,
+} from '../../lib/errors.js';
+import type { MigrationMode } from '../../core/types.js';
+
+interface MigrateSessionOptions {
+  dryRun?: boolean;
+  copy?: boolean;
+  force?: boolean;
+  dataPath?: string;
+  json?: boolean;
+}
+
+export function registerMigrateSessionCommand(program: Command): void {
+  program
+    .command('migrate-session')
+    .description('Move or copy sessions to a different workspace')
+    .argument('<session>', 'Session index or ID (comma-separated for multiple)')
+    .argument('<destination>', 'Destination workspace path')
+    .option('--dry-run', 'Preview migration without making changes')
+    .option('--copy', 'Copy sessions instead of moving (keeps originals)')
+    .option('-f, --force', 'Proceed even if destination has existing sessions')
+    .action(async (sessionArg: string, destinationArg: string, options: MigrateSessionOptions) => {
+      const globalOptions = program.opts() as { dataPath?: string; json?: boolean };
+      const dataPath = globalOptions.dataPath;
+      const jsonOutput = globalOptions.json || options.json;
+
+      try {
+        // Expand ~ in destination path
+        const destination = expandPath(destinationArg);
+
+        // Resolve session identifiers to IDs
+        const sessionIds = resolveSessionIdentifiers(sessionArg, dataPath);
+
+        // Determine mode
+        const mode: MigrationMode = options.copy ? 'copy' : 'move';
+
+        // Perform migration
+        const results = migrateSessions({
+          sessionIds,
+          destination,
+          mode,
+          dryRun: options.dryRun ?? false,
+          force: options.force ?? false,
+          dataPath,
+        });
+
+        // Output results
+        if (jsonOutput) {
+          console.log(JSON.stringify(results, null, 2));
+        } else {
+          outputResults(results, options.dryRun ?? false);
+        }
+
+        // Exit with error code if any failures
+        const hasFailures = results.some((r) => !r.success);
+        if (hasFailures) {
+          process.exit(1);
+        }
+      } catch (error) {
+        if (jsonOutput) {
+          console.log(JSON.stringify({ error: formatError(error) }, null, 2));
+        } else {
+          console.error(pc.red(formatError(error)));
+        }
+        process.exit(1);
+      }
+    });
+}
+
+function outputResults(
+  results: Array<{
+    success: boolean;
+    sessionId: string;
+    sourceWorkspace: string;
+    destinationWorkspace: string;
+    mode: MigrationMode;
+    newSessionId?: string;
+    error?: string;
+    dryRun: boolean;
+  }>,
+  isDryRun: boolean
+): void {
+  if (isDryRun) {
+    console.log(pc.yellow('Dry run - no changes made\n'));
+  }
+
+  const successful = results.filter((r) => r.success);
+  const failed = results.filter((r) => !r.success);
+
+  if (successful.length > 0) {
+    const action = isDryRun ? 'Would migrate' : 'Migrated';
+    console.log(pc.green(`${action} ${successful.length} session(s):\n`));
+
+    for (const result of successful) {
+      const modeLabel = result.mode === 'copy' ? 'copied' : 'moved';
+      const actionLabel = isDryRun ? `would be ${modeLabel}` : modeLabel;
+      console.log(`  ${pc.cyan(result.sessionId.slice(0, 8))}...`);
+      console.log(`    From: ${result.sourceWorkspace}`);
+      console.log(`    To:   ${result.destinationWorkspace}`);
+      console.log(`    ${pc.dim(`(${actionLabel})`)}\n`);
+    }
+  }
+
+  if (failed.length > 0) {
+    console.log(pc.red(`Failed to migrate ${failed.length} session(s):\n`));
+
+    for (const result of failed) {
+      console.log(`  ${pc.red('✗')} ${pc.cyan(result.sessionId.slice(0, 8))}...`);
+      console.log(`    ${pc.red(result.error ?? 'Unknown error')}\n`);
+    }
+  }
+
+  // Summary
+  if (results.length > 1) {
+    console.log(pc.dim(`Summary: ${successful.length} succeeded, ${failed.length} failed`));
+  }
+}
+
+function formatError(error: unknown): string {
+  if (isSessionNotFoundError(error)) {
+    return `Session not found: ${error.identifier}\nRun 'cursor-history list' to see available sessions.`;
+  }
+
+  if (isWorkspaceNotFoundError(error)) {
+    return `Workspace not found: ${error.path}\nPlease open the project in Cursor first to create the workspace.`;
+  }
+
+  if (isSameWorkspaceError(error)) {
+    return `Source and destination are the same: ${error.path}\nSpecify a different destination path.`;
+  }
+
+  if (error instanceof Error) {
+    // Check for database lock error
+    if (error.message.includes('SQLITE_BUSY') || error.message.includes('database is locked')) {
+      return 'Database is locked. Please close Cursor and try again.';
+    }
+    return error.message;
+  }
+
+  return String(error);
+}

--- a/src/cli/commands/migrate.ts
+++ b/src/cli/commands/migrate.ts
@@ -1,0 +1,147 @@
+/**
+ * CLI command for migrating all sessions between workspaces
+ *
+ * Usage:
+ *   cursor-history migrate <source> <destination>
+ *   cursor-history migrate /old/project /new/project
+ *   cursor-history migrate --copy /project /backup/project
+ *   cursor-history migrate --dry-run /old/path /new/path
+ *   cursor-history migrate --force /old/path /existing/path
+ */
+
+import { Command } from 'commander';
+import pc from 'picocolors';
+import { migrateWorkspace } from '../../core/migrate.js';
+import { expandPath } from '../../lib/platform.js';
+import {
+  isWorkspaceNotFoundError,
+  isSameWorkspaceError,
+  isNoSessionsFoundError,
+  isDestinationHasSessionsError,
+} from '../../lib/errors.js';
+import type { MigrationMode, WorkspaceMigrationResult } from '../../core/types.js';
+
+interface MigrateOptions {
+  dryRun?: boolean;
+  copy?: boolean;
+  force?: boolean;
+  dataPath?: string;
+  json?: boolean;
+}
+
+export function registerMigrateCommand(program: Command): void {
+  program
+    .command('migrate')
+    .description('Move or copy all sessions from one workspace to another')
+    .argument('<source>', 'Source workspace path')
+    .argument('<destination>', 'Destination workspace path')
+    .option('--dry-run', 'Preview migration without making changes')
+    .option('--copy', 'Copy sessions instead of moving (keeps originals)')
+    .option('-f, --force', 'Proceed even if destination has existing sessions')
+    .action(async (sourceArg: string, destinationArg: string, options: MigrateOptions) => {
+      const globalOptions = program.opts() as { dataPath?: string; json?: boolean };
+      const dataPath = globalOptions.dataPath;
+      const jsonOutput = globalOptions.json || options.json;
+
+      try {
+        // Expand ~ in paths
+        const source = expandPath(sourceArg);
+        const destination = expandPath(destinationArg);
+
+        // Determine mode
+        const mode: MigrationMode = options.copy ? 'copy' : 'move';
+
+        // Perform migration
+        const result = migrateWorkspace({
+          source,
+          destination,
+          mode,
+          dryRun: options.dryRun ?? false,
+          force: options.force ?? false,
+          dataPath,
+        });
+
+        // Output results
+        if (jsonOutput) {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          outputResult(result);
+        }
+
+        // Exit with error code if any failures
+        if (!result.success) {
+          process.exit(1);
+        }
+      } catch (error) {
+        if (jsonOutput) {
+          console.log(JSON.stringify({ error: formatError(error) }, null, 2));
+        } else {
+          console.error(pc.red(formatError(error)));
+        }
+        process.exit(1);
+      }
+    });
+}
+
+function outputResult(result: WorkspaceMigrationResult): void {
+  if (result.dryRun) {
+    console.log(pc.yellow('Dry run - no changes made\n'));
+  }
+
+  const action = result.dryRun ? 'Would migrate' : 'Migrated';
+  const modeLabel = result.mode === 'copy' ? 'copied' : 'moved';
+
+  console.log(`${action} ${pc.bold(result.totalSessions)} session(s) from:`);
+  console.log(`  ${pc.cyan(result.source)}`);
+  console.log(`to:`);
+  console.log(`  ${pc.cyan(result.destination)}\n`);
+
+  if (result.successCount > 0) {
+    const actionLabel = result.dryRun ? `would be ${modeLabel}` : modeLabel;
+    console.log(pc.green(`✓ ${result.successCount} session(s) ${actionLabel} successfully`));
+  }
+
+  if (result.failureCount > 0) {
+    console.log(pc.red(`✗ ${result.failureCount} session(s) failed to migrate:\n`));
+
+    for (const r of result.results.filter((r) => !r.success)) {
+      console.log(`  ${pc.red('✗')} ${pc.cyan(r.sessionId.slice(0, 8))}...`);
+      console.log(`    ${pc.red(r.error ?? 'Unknown error')}\n`);
+    }
+  }
+
+  // Overall status
+  if (result.success) {
+    console.log(pc.green('\n✓ Migration completed successfully'));
+  } else {
+    console.log(pc.red('\n✗ Migration completed with errors'));
+  }
+}
+
+function formatError(error: unknown): string {
+  if (isWorkspaceNotFoundError(error)) {
+    return `Workspace not found: ${error.path}\nPlease open the project in Cursor first to create the workspace.`;
+  }
+
+  if (isSameWorkspaceError(error)) {
+    return `Source and destination are the same: ${error.path}\nSpecify different source and destination paths.`;
+  }
+
+  if (isNoSessionsFoundError(error)) {
+    return `No sessions found for workspace: ${error.path}\nRun 'cursor-history list --workspace "${error.path}"' to verify.`;
+  }
+
+  if (isDestinationHasSessionsError(error)) {
+    return `Destination already has ${error.sessionCount} session(s): ${error.path}\nUse --force to proceed (will add sessions alongside existing ones).`;
+  }
+
+  if (error instanceof Error) {
+    // Check for database lock error
+    if (error.message.includes('SQLITE_BUSY') || error.message.includes('database is locked')) {
+      return 'Database is locked. Please close Cursor and try again.';
+    }
+    return error.message;
+  }
+
+  return String(error);
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -33,11 +33,15 @@ async function loadCommands() {
   const { registerShowCommand } = await import('./commands/show.js');
   const { registerSearchCommand } = await import('./commands/search.js');
   const { registerExportCommand } = await import('./commands/export.js');
+  const { registerMigrateSessionCommand } = await import('./commands/migrate-session.js');
+  const { registerMigrateCommand } = await import('./commands/migrate.js');
 
   registerListCommand(program);
   registerShowCommand(program);
   registerSearchCommand(program);
   registerExportCommand(program);
+  registerMigrateSessionCommand(program);
+  registerMigrateCommand(program);
 }
 
 // Main execution

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -1,0 +1,426 @@
+/**
+ * Core migration logic for Cursor chat history
+ *
+ * This module provides session-level migration as the core primitive.
+ * Workspace-level migration is built on top of session migration.
+ */
+
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import Database from 'better-sqlite3';
+import {
+  findWorkspaceForSession,
+  findWorkspaceByPath,
+  openDatabaseReadWrite,
+  getComposerData,
+  updateComposerData,
+} from './storage.js';
+import { normalizePath, pathsEqual } from '../lib/platform.js';
+import {
+  SessionNotFoundError,
+  WorkspaceNotFoundError,
+  SameWorkspaceError,
+  NoSessionsFoundError,
+  DestinationHasSessionsError,
+} from '../lib/errors.js';
+import type {
+  MigrateSessionOptions,
+  MigrateWorkspaceOptions,
+  SessionMigrationResult,
+  WorkspaceMigrationResult,
+} from './types.js';
+
+/**
+ * Generate a new unique session ID (UUID v4 format)
+ */
+function generateSessionId(): string {
+  // Simple UUID v4 generator
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+/**
+ * Get the global Cursor storage path
+ */
+function getGlobalStoragePath(): string {
+  const platform = process.platform;
+  const home = homedir();
+
+  if (platform === 'win32') {
+    return join(process.env['APPDATA'] ?? join(home, 'AppData', 'Roaming'), 'Cursor', 'User', 'globalStorage');
+  } else if (platform === 'darwin') {
+    return join(home, 'Library', 'Application Support', 'Cursor', 'User', 'globalStorage');
+  } else {
+    return join(home, '.config', 'Cursor', 'User', 'globalStorage');
+  }
+}
+
+/**
+ * Copy all bubble data for a session in global storage with new IDs.
+ * This is required for copy mode to create independent session data.
+ *
+ * @param oldComposerId - Original composer ID
+ * @param newComposerId - New composer ID for the copy
+ * @returns Map of old bubble IDs to new bubble IDs
+ */
+function copyBubbleDataInGlobalStorage(
+  oldComposerId: string,
+  newComposerId: string
+): Map<string, string> {
+  const globalDbPath = join(getGlobalStoragePath(), 'state.vscdb');
+
+  if (!existsSync(globalDbPath)) {
+    return new Map();
+  }
+
+  const bubbleIdMap = new Map<string, string>();
+  const db = new Database(globalDbPath, { readonly: false });
+
+  try {
+    // 1. Copy composerData entry with new ID
+    const composerDataRow = db.prepare(
+      "SELECT value FROM cursorDiskKV WHERE key = ?"
+    ).get(`composerData:${oldComposerId}`) as { value: string } | undefined;
+
+    if (composerDataRow) {
+      const composerData = JSON.parse(composerDataRow.value);
+
+      // Update composerId in the data
+      composerData.composerId = newComposerId;
+
+      // We'll update fullConversationHeadersOnly after generating new bubble IDs
+      const oldBubbleHeaders = composerData.fullConversationHeadersOnly || [];
+
+      // Generate new bubble IDs and build the mapping
+      const newBubbleHeaders: Array<{ bubbleId: string; type: number; serverBubbleId?: string }> = [];
+      for (const header of oldBubbleHeaders) {
+        if (header.bubbleId) {
+          const newBubbleId = generateSessionId();
+          bubbleIdMap.set(header.bubbleId, newBubbleId);
+          newBubbleHeaders.push({
+            ...header,
+            bubbleId: newBubbleId,
+          });
+        }
+      }
+      composerData.fullConversationHeadersOnly = newBubbleHeaders;
+
+      // Insert new composerData
+      db.prepare(
+        "INSERT OR REPLACE INTO cursorDiskKV (key, value) VALUES (?, ?)"
+      ).run(`composerData:${newComposerId}`, JSON.stringify(composerData));
+    }
+
+    // 2. Copy all bubble entries with new IDs
+    const bubbleRows = db.prepare(
+      "SELECT key, value FROM cursorDiskKV WHERE key LIKE ?"
+    ).all(`bubbleId:${oldComposerId}:%`) as Array<{ key: string; value: string }>;
+
+    for (const row of bubbleRows) {
+      // Extract old bubble ID from key: bubbleId:<composerId>:<bubbleId>
+      const parts = row.key.split(':');
+      const oldBubbleId = parts[2];
+
+      if (!oldBubbleId) continue;
+
+      // Get or generate new bubble ID
+      let newBubbleId = bubbleIdMap.get(oldBubbleId);
+      if (!newBubbleId) {
+        newBubbleId = generateSessionId();
+        bubbleIdMap.set(oldBubbleId, newBubbleId);
+      }
+
+      // Parse and update the bubble data
+      const bubbleData = JSON.parse(row.value);
+      bubbleData.bubbleId = newBubbleId;
+
+      // Create new key with new IDs
+      const newKey = `bubbleId:${newComposerId}:${newBubbleId}`;
+
+      // Insert the copied bubble
+      db.prepare(
+        "INSERT OR REPLACE INTO cursorDiskKV (key, value) VALUES (?, ?)"
+      ).run(newKey, JSON.stringify(bubbleData));
+    }
+
+    return bubbleIdMap;
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Migrate a single session from its current workspace to a destination workspace.
+ *
+ * This is the core primitive for all migration operations.
+ * Move mode: removes session from source, adds to destination.
+ * Copy mode: duplicates session to destination, keeps source intact.
+ *
+ * @param sessionId - The session ID to migrate
+ * @param options - Migration options
+ * @returns Migration result for this session
+ */
+export function migrateSession(
+  sessionId: string,
+  options: Omit<MigrateSessionOptions, 'sessionIds'>
+): SessionMigrationResult {
+  const { destination, mode, dryRun, dataPath } = options;
+  // Note: force option is used at the CLI layer for validation, not in core migration
+
+  // Normalize destination path
+  const normalizedDest = normalizePath(destination);
+
+  // Find source workspace for this session
+  const sourceInfo = findWorkspaceForSession(sessionId, dataPath);
+  if (!sourceInfo) {
+    throw new SessionNotFoundError(sessionId);
+  }
+
+  const sourceWorkspace = sourceInfo.workspace.path;
+
+  // Check if source and destination are the same
+  if (pathsEqual(sourceWorkspace, normalizedDest)) {
+    throw new SameWorkspaceError(normalizedDest);
+  }
+
+  // Find destination workspace
+  const destInfo = findWorkspaceByPath(normalizedDest, dataPath);
+  if (!destInfo) {
+    throw new WorkspaceNotFoundError(normalizedDest);
+  }
+
+  // If dry run, return preview result without making changes
+  if (dryRun) {
+    return {
+      success: true,
+      sessionId,
+      sourceWorkspace,
+      destinationWorkspace: normalizedDest,
+      mode,
+      dryRun: true,
+    };
+  }
+
+  // Perform the actual migration
+  try {
+    // Open both databases for read-write
+    const sourceDb = openDatabaseReadWrite(sourceInfo.dbPath);
+    const destDb = openDatabaseReadWrite(destInfo.dbPath);
+
+    try {
+      // Get composer data from both workspaces
+      const sourceResult = getComposerData(sourceDb);
+      const destResult = getComposerData(destDb);
+
+      if (!sourceResult) {
+        throw new Error('Source workspace has no composer data');
+      }
+
+      // Find the session in source data
+      const sessionIndex = sourceResult.composers.findIndex((s) => s.composerId === sessionId);
+      if (sessionIndex === -1) {
+        throw new SessionNotFoundError(sessionId);
+      }
+
+      const sessionToMigrate = sourceResult.composers[sessionIndex]!;
+
+      if (mode === 'move') {
+        // Remove from source
+        const newSourceComposers = sourceResult.composers.filter((_, i) => i !== sessionIndex);
+        updateComposerData(sourceDb, newSourceComposers, sourceResult.isNewFormat, sourceResult.rawData);
+
+        // Add to destination
+        const destComposers = destResult ? destResult.composers : [];
+        const newDestComposers = [...destComposers, sessionToMigrate];
+        updateComposerData(
+          destDb,
+          newDestComposers,
+          destResult?.isNewFormat ?? sourceResult.isNewFormat,
+          destResult?.rawData
+        );
+
+        return {
+          success: true,
+          sessionId,
+          sourceWorkspace,
+          destinationWorkspace: normalizedDest,
+          mode: 'move',
+          dryRun: false,
+        };
+      } else {
+        // Copy mode - duplicate session to destination, keep source intact
+        // Generate new session ID for the copy
+        const newSessionId = generateSessionId();
+
+        // Copy all bubble data in global storage with new IDs
+        // This ensures the copy is fully independent from the original
+        copyBubbleDataInGlobalStorage(sessionId, newSessionId);
+
+        // Deep clone and update the session with new ID
+        const copiedSession = JSON.parse(JSON.stringify(sessionToMigrate)) as { composerId?: string };
+        copiedSession.composerId = newSessionId;
+
+        // Add to destination (don't modify source)
+        const destComposers = destResult ? destResult.composers : [];
+        const newDestComposers = [...destComposers, copiedSession];
+        updateComposerData(
+          destDb,
+          newDestComposers,
+          destResult?.isNewFormat ?? sourceResult.isNewFormat,
+          destResult?.rawData
+        );
+
+        return {
+          success: true,
+          sessionId,
+          sourceWorkspace,
+          destinationWorkspace: normalizedDest,
+          mode: 'copy',
+          newSessionId,
+          dryRun: false,
+        };
+      }
+    } finally {
+      sourceDb.close();
+      destDb.close();
+    }
+  } catch (error) {
+    // Return failure result instead of throwing for partial failure handling
+    return {
+      success: false,
+      sessionId,
+      sourceWorkspace,
+      destinationWorkspace: normalizedDest,
+      mode,
+      error: error instanceof Error ? error.message : String(error),
+      dryRun: false,
+    };
+  }
+}
+
+/**
+ * Migrate multiple sessions to a destination workspace.
+ *
+ * Handles batch migration with partial failure support.
+ * Each session is migrated independently - failures don't stop the batch.
+ *
+ * @param options - Migration options including session IDs
+ * @returns Array of results for each session
+ */
+export function migrateSessions(options: MigrateSessionOptions): SessionMigrationResult[] {
+  const { sessionIds, ...sessionOptions } = options;
+  const results: SessionMigrationResult[] = [];
+
+  for (const sessionId of sessionIds) {
+    try {
+      const result = migrateSession(sessionId, sessionOptions);
+      results.push(result);
+    } catch (error) {
+      // Convert thrown errors to result objects for partial failure handling
+      results.push({
+        success: false,
+        sessionId,
+        sourceWorkspace: 'unknown',
+        destinationWorkspace: options.destination,
+        mode: options.mode,
+        error: error instanceof Error ? error.message : String(error),
+        dryRun: options.dryRun,
+      });
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Migrate all sessions from one workspace to another.
+ *
+ * This is a convenience wrapper that finds all sessions in the source workspace
+ * and calls migrateSession for each one.
+ *
+ * @param options - Workspace migration options
+ * @returns Aggregate result with per-session details
+ */
+export function migrateWorkspace(options: MigrateWorkspaceOptions): WorkspaceMigrationResult {
+  const { source, destination, mode, dryRun, force, dataPath } = options;
+
+  // Normalize paths
+  const normalizedSource = normalizePath(source);
+  const normalizedDest = normalizePath(destination);
+
+  // Check if source and destination are the same
+  if (pathsEqual(normalizedSource, normalizedDest)) {
+    throw new SameWorkspaceError(normalizedSource);
+  }
+
+  // Find source workspace
+  const sourceInfo = findWorkspaceByPath(normalizedSource, dataPath);
+  if (!sourceInfo) {
+    throw new WorkspaceNotFoundError(normalizedSource);
+  }
+
+  // Find destination workspace
+  const destInfo = findWorkspaceByPath(normalizedDest, dataPath);
+  if (!destInfo) {
+    throw new WorkspaceNotFoundError(normalizedDest);
+  }
+
+  // Get sessions from source workspace
+  const sourceDb = openDatabaseReadWrite(sourceInfo.dbPath);
+  const sourceResult = getComposerData(sourceDb);
+  sourceDb.close();
+
+  if (!sourceResult || sourceResult.composers.length === 0) {
+    throw new NoSessionsFoundError(normalizedSource);
+  }
+
+  // Check if destination has existing sessions (unless force is set)
+  if (!force) {
+    const destDb = openDatabaseReadWrite(destInfo.dbPath);
+    const destResult = getComposerData(destDb);
+    destDb.close();
+
+    if (destResult && destResult.composers.length > 0) {
+      throw new DestinationHasSessionsError(normalizedDest, destResult.composers.length);
+    }
+  }
+
+  // Extract session IDs
+  const sessionIds = sourceResult.composers
+    .map((s) => s.composerId)
+    .filter((id): id is string => typeof id === 'string');
+
+  if (sessionIds.length === 0) {
+    throw new NoSessionsFoundError(normalizedSource);
+  }
+
+  // Migrate all sessions
+  const results = migrateSessions({
+    sessionIds,
+    destination: normalizedDest,
+    mode,
+    dryRun,
+    force,
+    dataPath,
+  });
+
+  // Aggregate results
+  const successCount = results.filter((r) => r.success).length;
+  const failureCount = results.filter((r) => !r.success).length;
+
+  return {
+    success: failureCount === 0,
+    source: normalizedSource,
+    destination: normalizedDest,
+    mode,
+    totalSessions: results.length,
+    successCount,
+    failureCount,
+    results,
+    dryRun,
+  };
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -151,3 +151,94 @@ export interface ExportOptions {
   outputPath?: string;
   force: boolean;
 }
+
+// ============================================================================
+// Migration Types
+// ============================================================================
+
+/**
+ * Migration mode: move removes from source, copy keeps source intact
+ */
+export type MigrationMode = 'move' | 'copy';
+
+/**
+ * Options for migrating one or more sessions
+ */
+export interface MigrateSessionOptions {
+  /** Session ID(s) to migrate (resolved from index or UUID) */
+  sessionIds: string[];
+  /** Destination workspace path */
+  destination: string;
+  /** Migration mode: 'move' (default) or 'copy' */
+  mode: MigrationMode;
+  /** If true, preview without making changes */
+  dryRun: boolean;
+  /** If true, proceed even if destination has existing history */
+  force: boolean;
+  /** Custom Cursor data path (optional) */
+  dataPath?: string;
+}
+
+/**
+ * Options for migrating all sessions from a workspace
+ */
+export interface MigrateWorkspaceOptions {
+  /** Source workspace path */
+  source: string;
+  /** Destination workspace path */
+  destination: string;
+  /** Migration mode: 'move' (default) or 'copy' */
+  mode: MigrationMode;
+  /** If true, preview without making changes */
+  dryRun: boolean;
+  /** If true, proceed even if destination has existing history */
+  force: boolean;
+  /** Custom Cursor data path (optional) */
+  dataPath?: string;
+}
+
+/**
+ * Result of migrating a single session
+ */
+export interface SessionMigrationResult {
+  /** Whether migration succeeded */
+  success: boolean;
+  /** Original session ID */
+  sessionId: string;
+  /** Source workspace path */
+  sourceWorkspace: string;
+  /** Destination workspace path */
+  destinationWorkspace: string;
+  /** Mode used for migration */
+  mode: MigrationMode;
+  /** For copy mode: the new session ID created */
+  newSessionId?: string;
+  /** Error message if success is false */
+  error?: string;
+  /** Whether this was a dry run */
+  dryRun: boolean;
+}
+
+/**
+ * Aggregate result of workspace migration
+ */
+export interface WorkspaceMigrationResult {
+  /** True if all sessions migrated successfully */
+  success: boolean;
+  /** Normalized source path */
+  source: string;
+  /** Normalized destination path */
+  destination: string;
+  /** Mode used for migration */
+  mode: MigrationMode;
+  /** Total number of sessions attempted */
+  totalSessions: number;
+  /** Number of successful migrations */
+  successCount: number;
+  /** Number of failed migrations */
+  failureCount: number;
+  /** Per-session results */
+  results: SessionMigrationResult[];
+  /** Whether this was a dry run */
+  dryRun: boolean;
+}

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -89,3 +89,149 @@ export function isDatabaseNotFoundError(error: unknown): error is DatabaseNotFou
 export function isInvalidConfigError(error: unknown): error is InvalidConfigError {
   return error instanceof InvalidConfigError;
 }
+
+// ============================================================================
+// Migration Errors
+// ============================================================================
+
+/**
+ * Thrown when a session ID or index cannot be resolved.
+ *
+ * Recovery: Check session exists with `listSessions()`, use valid ID or index.
+ */
+export class SessionNotFoundError extends Error {
+  name = 'SessionNotFoundError' as const;
+
+  /** The identifier that was not found (index or UUID) */
+  identifier: string | number;
+
+  constructor(identifier: string | number) {
+    super(`Session not found: ${identifier}. Use 'cursor-history list' to see available sessions.`);
+    this.identifier = identifier;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, SessionNotFoundError);
+    }
+  }
+}
+
+/**
+ * Thrown when destination workspace path has no workspace directory.
+ *
+ * Recovery: Open the project in Cursor first to create the workspace directory.
+ */
+export class WorkspaceNotFoundError extends Error {
+  name = 'WorkspaceNotFoundError' as const;
+
+  /** The workspace path that was not found */
+  path: string;
+
+  constructor(path: string) {
+    super(`No workspace found for path: ${path}. Please open the project in Cursor first.`);
+    this.path = path;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, WorkspaceNotFoundError);
+    }
+  }
+}
+
+/**
+ * Thrown when source and destination paths are the same.
+ *
+ * Recovery: Specify different source and destination paths.
+ */
+export class SameWorkspaceError extends Error {
+  name = 'SameWorkspaceError' as const;
+
+  /** The path that was specified for both source and destination */
+  path: string;
+
+  constructor(path: string) {
+    super(`Source and destination are the same: ${path}`);
+    this.path = path;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, SameWorkspaceError);
+    }
+  }
+}
+
+/**
+ * Thrown when no sessions are found for the specified source workspace.
+ *
+ * Recovery: Check the source path is correct, verify sessions exist with `list --workspace`.
+ */
+export class NoSessionsFoundError extends Error {
+  name = 'NoSessionsFoundError' as const;
+
+  /** The source workspace path */
+  path: string;
+
+  constructor(path: string) {
+    super(`No sessions found for workspace: ${path}. Use 'cursor-history list --workspace "${path}"' to verify.`);
+    this.path = path;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, NoSessionsFoundError);
+    }
+  }
+}
+
+/**
+ * Thrown when destination has existing sessions and --force not specified.
+ *
+ * Recovery: Use --force flag to proceed with additive merge.
+ */
+export class DestinationHasSessionsError extends Error {
+  name = 'DestinationHasSessionsError' as const;
+
+  /** The destination workspace path */
+  path: string;
+
+  /** Number of existing sessions at destination */
+  sessionCount: number;
+
+  constructor(path: string, sessionCount: number) {
+    super(
+      `Destination already has ${sessionCount} session(s): ${path}. ` +
+        `Use --force to proceed (will add sessions alongside existing ones).`
+    );
+    this.path = path;
+    this.sessionCount = sessionCount;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, DestinationHasSessionsError);
+    }
+  }
+}
+
+/**
+ * Type guard to check if an error is a SessionNotFoundError.
+ */
+export function isSessionNotFoundError(error: unknown): error is SessionNotFoundError {
+  return error instanceof SessionNotFoundError;
+}
+
+/**
+ * Type guard to check if an error is a WorkspaceNotFoundError.
+ */
+export function isWorkspaceNotFoundError(error: unknown): error is WorkspaceNotFoundError {
+  return error instanceof WorkspaceNotFoundError;
+}
+
+/**
+ * Type guard to check if an error is a SameWorkspaceError.
+ */
+export function isSameWorkspaceError(error: unknown): error is SameWorkspaceError {
+  return error instanceof SameWorkspaceError;
+}
+
+/**
+ * Type guard to check if an error is a NoSessionsFoundError.
+ */
+export function isNoSessionsFoundError(error: unknown): error is NoSessionsFoundError {
+  return error instanceof NoSessionsFoundError;
+}
+
+/**
+ * Type guard to check if an error is a DestinationHasSessionsError.
+ */
+export function isDestinationHasSessionsError(error: unknown): error is DestinationHasSessionsError {
+  return error instanceof DestinationHasSessionsError;
+}

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -85,3 +85,41 @@ export function contractPath(path: string): string {
   }
   return path;
 }
+
+/**
+ * Normalize a file path for consistent comparison
+ * - Resolves ~ to home directory
+ * - Removes trailing slashes
+ * - Normalizes path separators
+ */
+export function normalizePath(filePath: string): string {
+  // Expand ~ to home directory
+  let normalized = filePath;
+  if (normalized.startsWith('~')) {
+    normalized = join(homedir(), normalized.slice(1));
+  }
+
+  // Remove trailing slashes (but keep root /)
+  while (normalized.length > 1 && normalized.endsWith('/')) {
+    normalized = normalized.slice(0, -1);
+  }
+  while (normalized.length > 1 && normalized.endsWith('\\')) {
+    normalized = normalized.slice(0, -1);
+  }
+
+  return normalized;
+}
+
+/**
+ * Compare two paths for equality (case-sensitive on Unix, case-insensitive on Windows)
+ */
+export function pathsEqual(path1: string, path2: string): boolean {
+  const normalized1 = normalizePath(path1);
+  const normalized2 = normalizePath(path2);
+
+  if (process.platform === 'win32') {
+    return normalized1.toLowerCase() === normalized2.toLowerCase();
+  }
+
+  return normalized1 === normalized2;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -152,3 +152,126 @@ export interface PaginatedResult<T> {
     hasMore: boolean;
   };
 }
+
+// ============================================================================
+// Migration Types (Library API)
+// ============================================================================
+
+/**
+ * Migration mode: move removes from source, copy keeps source intact
+ */
+export type MigrationMode = 'move' | 'copy';
+
+/**
+ * Configuration for session-level migration.
+ */
+export interface MigrateSessionConfig {
+  /**
+   * Session identifier(s) to migrate.
+   * Can be:
+   * - Single session ID (UUID): "abc123-def456"
+   * - Single index (1-based): "3" or 3
+   * - Multiple comma-separated: "1,3,5" or "abc123,def456"
+   * - Array of IDs/indices: ["1", "3"] or [1, 3]
+   */
+  sessions: string | number | (string | number)[];
+
+  /** Destination workspace path (absolute or relative, resolved to absolute) */
+  destination: string;
+
+  /** Migration mode: 'move' (default) or 'copy' */
+  mode?: MigrationMode;
+
+  /** If true, preview without making changes */
+  dryRun?: boolean;
+
+  /** If true, proceed even if destination has existing history */
+  force?: boolean;
+
+  /** Custom Cursor data path (optional, uses default if not specified) */
+  dataPath?: string;
+}
+
+/**
+ * Configuration for workspace-level migration.
+ */
+export interface MigrateWorkspaceConfig {
+  /** Source workspace path to migrate from (exact match) */
+  source: string;
+
+  /** Destination workspace path to migrate to */
+  destination: string;
+
+  /** Migration mode: 'move' (default) or 'copy' */
+  mode?: MigrationMode;
+
+  /** If true, preview without making changes */
+  dryRun?: boolean;
+
+  /** If true, proceed even if destination has existing history */
+  force?: boolean;
+
+  /** Custom Cursor data path (optional, uses default if not specified) */
+  dataPath?: string;
+}
+
+/**
+ * Result of migrating a single session.
+ */
+export interface SessionMigrationResult {
+  /** Whether migration succeeded */
+  success: boolean;
+
+  /** Original session ID */
+  sessionId: string;
+
+  /** Source workspace path */
+  sourceWorkspace: string;
+
+  /** Destination workspace path */
+  destinationWorkspace: string;
+
+  /** Mode used for migration */
+  mode: MigrationMode;
+
+  /** For copy mode: the new session ID created */
+  newSessionId?: string;
+
+  /** Error message if success is false */
+  error?: string;
+
+  /** Whether this was a dry run */
+  dryRun: boolean;
+}
+
+/**
+ * Aggregate result of workspace migration.
+ */
+export interface WorkspaceMigrationResult {
+  /** True if all sessions migrated successfully */
+  success: boolean;
+
+  /** Normalized source path */
+  source: string;
+
+  /** Normalized destination path */
+  destination: string;
+
+  /** Mode used for migration */
+  mode: MigrationMode;
+
+  /** Total number of sessions attempted */
+  totalSessions: number;
+
+  /** Number of successful migrations */
+  successCount: number;
+
+  /** Number of failed migrations */
+  failureCount: number;
+
+  /** Per-session results */
+  results: SessionMigrationResult[];
+
+  /** Whether this was a dry run */
+  dryRun: boolean;
+}


### PR DESCRIPTION
Add migrate-session and migrate commands to move or copy chat sessions between Cursor workspaces. Key features:

- Single session migration: `migrate-session <id> <dest>`
- Multiple sessions: `migrate-session 1,3,5 <dest>`
- Workspace-level: `migrate <source> <dest>`
- Copy mode with --copy flag (creates independent copy with new IDs)
- Dry-run preview with --dry-run flag
- Force merge with --force flag

Copy mode now properly duplicates all data in global storage:
- Generates new composer ID and bubble IDs
- Copies composerData and all bubble entries
- No shared references between original and copy

Also adds library API: migrateSession() and migrateWorkspace()