### PR TITLE
fix: replace adm-zip with jszip for ESM bundling compatibility (v0.9.2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -356,6 +356,8 @@ Edit `extractBubbleText()` in `src/core/storage.ts`. Priority matters:
 - commander + picocolors for CLI (not used in library)
 - Dual ESM/CommonJS module support
 - SQLite databases (state.vscdb files) + zip archives for backups
+- TypeScript 5.9+ (strict mode enabled) + jszip (replacing adm-zip), commander, picocolors, better-sqlite3/node:sqlite (007-replace-adm-zip)
+- SQLite databases (state.vscdb), zip archives for backup (007-replace-adm-zip)
 
 ## Recent Changes
 - 006-pluggable-sqlite-driver: Added pluggable SQLite driver system

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,23 @@
 {
   "name": "cursor-history",
-  "version": "0.7.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cursor-history",
-      "version": "0.7.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
-        "adm-zip": "^0.5.16",
         "better-sqlite3": "^12.5.0",
         "commander": "^14.0.2",
+        "jszip": "^3.10.1",
         "picocolors": "^1.1.1"
       },
       "bin": {
         "cursor-history": "dist/cli/index.js"
       },
       "devDependencies": {
-        "@types/adm-zip": "^0.5.7",
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^25.0.3",
         "eslint": "^9.39.2",
@@ -1004,16 +1003,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/adm-zip": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.7.tgz",
-      "integrity": "sha512-DNEs/QvmyRLurdQPChqq0Md4zGvPwHerAJYWk9l2jCbD1VPpnzRJorOdiq4zsw09NFbYnhfsoEhWtxIzXpn2yw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
@@ -1458,15 +1447,6 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1690,6 +1670,12 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -2209,6 +2195,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -2271,6 +2263,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2312,6 +2310,48 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -2334,6 +2374,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/locate-path": {
@@ -2530,6 +2579,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -2671,6 +2726,12 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/pump": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
@@ -2803,6 +2864,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cursor-history",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "The ultimate CLI tool and library to browse, search, export, migrate, and backup your Cursor AI chat history",
   "type": "module",
   "main": "dist/lib/index.js",
@@ -74,13 +74,12 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
-    "adm-zip": "^0.5.16",
     "better-sqlite3": "^12.5.0",
     "commander": "^14.0.2",
+    "jszip": "^3.10.1",
     "picocolors": "^1.1.1"
   },
   "devDependencies": {
-    "@types/adm-zip": "^0.5.7",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^25.0.3",
     "eslint": "^9.39.2",

--- a/specs/007-replace-adm-zip/checklists/requirements.md
+++ b/specs/007-replace-adm-zip/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Replace adm-zip with ESM-Compatible Alternative
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-03
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation
+- The specification assumes jszip as the replacement library per the GitHub issue recommendation
+- The spec explicitly states that sync-to-async conversion is acceptable for jszip's Promise-based API
+- Ready for `/speckit.clarify` or `/speckit.plan`

--- a/specs/007-replace-adm-zip/data-model.md
+++ b/specs/007-replace-adm-zip/data-model.md
@@ -1,0 +1,52 @@
+# Data Model: Replace adm-zip with ESM-Compatible Alternative
+
+**Feature**: 007-replace-adm-zip
+**Date**: 2026-01-03
+
+## Overview
+
+This feature is a **dependency replacement** that does not introduce new data entities. The existing data model remains unchanged.
+
+## Existing Entities (No Changes)
+
+### BackupManifest
+Unchanged - describes backup contents, file paths, checksums, and metadata.
+
+### BackupArchive
+Unchanged - ZIP file structure with manifest.json and database files.
+
+### DatabaseFiles
+Unchanged - SQLite files at `globalStorage/state.vscdb` and `workspaceStorage/{id}/state.vscdb`.
+
+## API Impact
+
+### Functions with Signature Changes
+
+The following core functions change from synchronous to asynchronous due to jszip's Promise-based API:
+
+| Function | Before | After |
+|----------|--------|-------|
+| `openBackupDatabase(backupPath, dbPath)` | `Database` | `Promise<Database>` |
+| `readBackupManifest(backupPath)` | `BackupManifest \| null` | `Promise<BackupManifest \| null>` |
+| `validateBackup(backupPath)` | `BackupValidation` | `Promise<BackupValidation>` |
+| `restoreBackup(config)` | `RestoreResult` | `Promise<RestoreResult>` |
+| `listBackups(directory?)` | `BackupInfo[]` | `Promise<BackupInfo[]>` |
+
+### Library API Updates
+
+The library wrappers in `src/lib/backup.ts` must be updated to match:
+
+```typescript
+// These become async
+export async function restoreBackup(config): Promise<RestoreResult>
+export async function validateBackup(path): Promise<BackupValidation>
+export async function listBackups(dir?): Promise<BackupInfo[]>
+```
+
+## State Transitions
+
+No changes - backup/restore lifecycle remains the same.
+
+## Data Flow
+
+No changes - the same data flows through the system, just processed asynchronously.

--- a/specs/007-replace-adm-zip/plan.md
+++ b/specs/007-replace-adm-zip/plan.md
@@ -1,0 +1,117 @@
+# Implementation Plan: Replace adm-zip with ESM-Compatible Alternative
+
+**Branch**: `007-replace-adm-zip` | **Date**: 2026-01-03 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/007-replace-adm-zip/spec.md`
+
+## Summary
+
+Replace the adm-zip dependency with jszip to resolve ESM bundling failures on Node.js v24+. The adm-zip library uses dynamic `require()` calls that Node.js v24 rejects in ESM contexts. jszip is a pure JavaScript implementation with proper ESM support that will enable downstream packages to bundle cursor-history as ESM format.
+
+**Technical Approach**: Replace all `AdmZip` usage with jszip's Promise-based API, converting synchronous operations to async where needed. Maintain identical zip file structure and backwards compatibility.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.9+ (strict mode enabled)
+**Primary Dependencies**: jszip (replacing adm-zip), commander, picocolors, better-sqlite3/node:sqlite
+**Storage**: SQLite databases (state.vscdb), zip archives for backup
+**Testing**: Vitest (test structure exists but no tests implemented yet)
+**Target Platform**: Node.js 20 LTS+, cross-platform (macOS, Windows, Linux)
+**Project Type**: Single project - CLI tool + library
+**Performance Goals**: No regression beyond 10% for backup operations under 100MB
+**Constraints**: Must work in both ESM and CommonJS contexts; backwards compatible with existing backup files
+**Scale/Scope**: CLI tool for local use, typical backups <100MB with <100 workspace databases
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Simplicity First | ✅ PASS | Direct 1:1 library replacement, minimal code changes |
+| II. CLI-Native Design | ✅ PASS | No change to CLI interface |
+| III. Documentation-Driven | ✅ PASS | CHANGELOG update required for dependency change |
+| IV. Incremental Delivery | ✅ PASS | Single focused PR with one concern |
+| V. Defensive Parsing | ✅ PASS | Error handling for corrupt zips preserved |
+
+**Technical Standards Check**:
+- TypeScript strict mode: ✅ Maintained
+- Minimize dependencies: ✅ jszip replaces adm-zip (no net increase)
+- GUI Extensibility: ✅ No impact on core logic decoupling
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/007-replace-adm-zip/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output (N/A - no new entities)
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (N/A - no API changes)
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── core/
+│   ├── backup.ts        # PRIMARY: Replace AdmZip usage (6 instances)
+│   ├── storage.ts       # SECONDARY: Replace AdmZip usage (1 instance)
+│   └── database/        # No changes needed
+├── cli/
+│   └── commands/        # No changes needed
+└── lib/
+    └── index.ts         # No changes needed (exports remain same)
+
+tests/
+└── unit/
+    └── backup/          # NEW: Add backup tests for jszip migration
+```
+
+**Structure Decision**: Single project structure maintained. Changes isolated to `src/core/backup.ts` and `src/core/storage.ts`. No structural changes to the codebase.
+
+## Complexity Tracking
+
+> No constitution violations to justify.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| N/A | N/A | N/A |
+
+## Implementation Notes
+
+### Key API Differences: adm-zip → jszip
+
+| adm-zip (sync) | jszip (async) | Notes |
+|----------------|---------------|-------|
+| `new AdmZip()` | `new JSZip()` | Same pattern |
+| `new AdmZip(path)` | `JSZip.loadAsync(buffer)` | Must read file first |
+| `zip.addLocalFile(path, dir, name)` | `zip.file(path, content)` | Must read file content |
+| `zip.addFile(name, buffer)` | `zip.file(name, buffer)` | Same pattern |
+| `zip.readFile(path)` | `zip.file(path).async('nodebuffer')` | Async extraction |
+| `zip.writeZip(path)` | `zip.generateAsync({type:'nodebuffer'})` | Then fs.writeFile |
+
+### Functions Requiring Changes
+
+1. **backup.ts**:
+   - `createBackup()` - Already async, add jszip operations
+   - `openBackupDatabase()` - Sync → Async (breaking change to signature)
+   - `readBackupManifest()` - Sync → Async (breaking change to signature)
+   - `validateBackup()` - Sync → Async (breaking change to signature)
+   - `restoreBackup()` - Already sync but uses zip, convert to async
+   - `listBackups()` - Calls readBackupManifest, needs async handling
+
+2. **storage.ts**:
+   - `readWorkspaceJsonFromBackup()` - Sync → Async
+   - `findWorkspacesFromBackup()` - Already async, minor changes
+
+### Breaking Changes
+
+The following functions will change from sync to async:
+- `openBackupDatabase()` → `openBackupDatabaseAsync()` (or update callers)
+- `readBackupManifest()` → async
+- `validateBackup()` → async
+
+Since these are internal core functions, the library API (`src/lib/index.ts`) may need updates if it exposes them directly.

--- a/specs/007-replace-adm-zip/quickstart.md
+++ b/specs/007-replace-adm-zip/quickstart.md
@@ -1,0 +1,150 @@
+# Quickstart: Replace adm-zip with jszip
+
+This guide covers the implementation of feature 007-replace-adm-zip.
+
+## Prerequisites
+
+- Node.js 20 LTS or higher
+- npm or pnpm
+
+## Step 1: Update Dependencies
+
+```bash
+# Remove adm-zip
+npm uninstall adm-zip @types/adm-zip
+
+# Install jszip
+npm install jszip
+```
+
+## Step 2: Update Imports
+
+Replace in affected files:
+
+```typescript
+// Before
+import AdmZip from 'adm-zip';
+
+// After
+import JSZip from 'jszip';
+import { readFile, writeFile } from 'node:fs/promises';
+```
+
+## Step 3: Key API Patterns
+
+### Creating a zip archive
+
+```typescript
+// Before (adm-zip)
+const zip = new AdmZip();
+zip.addLocalFile('/path/to/file.txt', 'dir/', 'file.txt');
+zip.addFile('manifest.json', Buffer.from(JSON.stringify(data)));
+zip.writeZip('/path/to/output.zip');
+
+// After (jszip)
+const zip = new JSZip();
+const fileContent = await readFile('/path/to/file.txt');
+zip.file('dir/file.txt', fileContent);
+zip.file('manifest.json', JSON.stringify(data));
+const content = await zip.generateAsync({ type: 'nodebuffer' });
+await writeFile('/path/to/output.zip', content);
+```
+
+### Reading from a zip archive
+
+```typescript
+// Before (adm-zip)
+const zip = new AdmZip('/path/to/archive.zip');
+const buffer = zip.readFile('manifest.json');
+
+// After (jszip)
+const data = await readFile('/path/to/archive.zip');
+const zip = await JSZip.loadAsync(data);
+const buffer = await zip.file('manifest.json')?.async('nodebuffer');
+```
+
+### Iterating files
+
+```typescript
+// Before (adm-zip)
+const zip = new AdmZip('/path/to/archive.zip');
+const entries = zip.getEntries();
+for (const entry of entries) {
+  console.log(entry.entryName);
+}
+
+// After (jszip)
+const data = await readFile('/path/to/archive.zip');
+const zip = await JSZip.loadAsync(data);
+zip.forEach((relativePath, file) => {
+  console.log(relativePath);
+});
+```
+
+## Step 4: Function Signature Changes
+
+Several functions must change from sync to async:
+
+| Function | Before | After |
+|----------|--------|-------|
+| `openBackupDatabase()` | `function` | `async function` |
+| `readBackupManifest()` | `function` | `async function` |
+| `validateBackup()` | `function` | `async function` |
+| `restoreBackup()` | `function` | `async function` |
+| `listBackups()` | `function` | `async function` |
+
+Update all callers to use `await`.
+
+## Step 5: Library API Updates
+
+Update `src/lib/backup.ts` to make the wrapper functions async:
+
+```typescript
+// Before
+export function restoreBackup(config: RestoreConfig): RestoreResult {
+  return coreRestoreBackup(config);
+}
+
+// After
+export async function restoreBackup(config: RestoreConfig): Promise<RestoreResult> {
+  return coreRestoreBackup(config);
+}
+```
+
+## Step 6: Testing
+
+1. Build the project:
+   ```bash
+   npm run build
+   ```
+
+2. Test backup operations:
+   ```bash
+   node dist/cli/index.js backup
+   node dist/cli/index.js backup list
+   node dist/cli/index.js backup validate <backup-file>
+   ```
+
+3. Test ESM bundling:
+   ```bash
+   # Create a test project that bundles cursor-history as ESM
+   # Verify no "Dynamic require of 'fs' is not supported" errors
+   ```
+
+## Files to Modify
+
+1. `src/core/backup.ts` - Main backup implementation (6 AdmZip usages)
+2. `src/core/storage.ts` - Backup data source (1 AdmZip usage)
+3. `src/lib/backup.ts` - Library API wrappers
+4. `package.json` - Dependency update
+
+## Validation Checklist
+
+- [ ] All existing backup tests pass
+- [ ] Backup create works (creates valid zip)
+- [ ] Backup restore works (extracts all files)
+- [ ] Backup validate works (checks checksums)
+- [ ] Backup list works (reads manifests)
+- [ ] Reading from backup works (`--backup` flag)
+- [ ] Old backup files can be read by new code
+- [ ] New backup files are standard ZIP format

--- a/specs/007-replace-adm-zip/research.md
+++ b/specs/007-replace-adm-zip/research.md
@@ -1,0 +1,145 @@
+# Research: Replace adm-zip with ESM-Compatible Alternative
+
+**Feature**: 007-replace-adm-zip
+**Date**: 2026-01-03
+**Status**: Complete
+
+## Research Questions
+
+### 1. Which ESM-compatible zip library should replace adm-zip?
+
+**Decision**: jszip v3.10.1
+
+**Rationale**:
+- Pure JavaScript implementation with no native bindings
+- Proper ESM support with `exports` field in package.json
+- No dynamic `require()` calls that break Node.js v24+ ESM bundling
+- Actively maintained (last release 2022, but stable API)
+- MIT licensed (compatible with project)
+- Well-documented Promise-based API
+- Recommended in the original GitHub issue
+
+**Alternatives Considered**:
+
+| Library | Pros | Cons | Decision |
+|---------|------|------|----------|
+| jszip | Pure JS, ESM-compatible, Promise API | Async-only (sync code needs refactoring) | ✅ Selected |
+| archiver + yauzl | Separate create/read packages, ESM-friendly | Two dependencies instead of one | ❌ Rejected (complexity) |
+| yazl + yauzl | Lightweight, streaming | Two packages, lower-level API | ❌ Rejected (complexity) |
+| fflate | Very fast, ESM-native | Lower-level API, less documentation | ❌ Rejected (API complexity) |
+
+### 2. What API changes are required for jszip migration?
+
+**Decision**: Convert synchronous zip operations to async
+
+**Rationale**:
+jszip's API is Promise-based by design. This aligns with modern JavaScript patterns and doesn't block the event loop during zip operations.
+
+**Key Transformations**:
+
+```typescript
+// adm-zip (sync)
+const zip = new AdmZip(backupPath);
+const buffer = zip.readFile('manifest.json');
+
+// jszip (async)
+const data = await readFile(backupPath);
+const zip = await JSZip.loadAsync(data);
+const buffer = await zip.file('manifest.json')?.async('nodebuffer');
+```
+
+### 3. Are there backwards compatibility concerns with existing backup files?
+
+**Decision**: No compatibility issues expected
+
+**Rationale**:
+- Both adm-zip and jszip use standard ZIP format (DEFLATE compression)
+- jszip can read any valid ZIP file regardless of which library created it
+- The ZIP file structure (manifest.json, database file paths) is controlled by our code, not the library
+- Cross-platform path handling (forward slashes in ZIP entries) is standard
+
+**Verification Needed**:
+- Test reading backup files created by adm-zip with jszip
+- Test that new backups are readable by older cursor-history versions (if installed)
+
+### 4. What is the impact on function signatures?
+
+**Decision**: Several functions must change from sync to async
+
+**Functions Affected**:
+
+| Function | Current | After Migration | Breaking? |
+|----------|---------|-----------------|-----------|
+| `createBackup()` | async | async | No |
+| `openBackupDatabase()` | sync | async | Yes (internal) |
+| `readBackupManifest()` | sync | async | Yes (internal) |
+| `validateBackup()` | sync | async | Yes (internal) |
+| `restoreBackup()` | sync | async | Yes (internal) |
+| `listBackups()` | sync | async | Yes (internal) |
+| `readWorkspaceJsonFromBackup()` | sync | async | No (private) |
+
+**Mitigation**:
+- All affected functions are internal (`src/core/`) not public library API
+- Library exports (`src/lib/index.ts`) may need updates if they wrap these
+- CLI commands already use async patterns, minimal changes expected
+
+### 5. Performance considerations
+
+**Decision**: No significant performance regression expected
+
+**Rationale**:
+- jszip is pure JavaScript vs adm-zip's pure JavaScript (no difference in this regard)
+- Async operations may actually improve perceived performance by not blocking
+- For typical backup sizes (<100MB), any difference is negligible
+- jszip has options for compression level that match defaults
+
+**Verification Needed**:
+- Benchmark backup creation for 50MB and 100MB test cases
+- Ensure no more than 10% regression per spec requirements
+
+## Dependencies
+
+### Add
+
+```json
+{
+  "dependencies": {
+    "jszip": "^3.10.1"
+  }
+}
+```
+
+### Remove
+
+```json
+{
+  "dependencies": {
+    "adm-zip": "^0.5.16"
+  },
+  "devDependencies": {
+    "@types/adm-zip": "^0.5.7"
+  }
+}
+```
+
+**Net Change**: -1 dependency (jszip has built-in types)
+
+## Implementation Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| API differences cause bugs | Medium | High | Comprehensive manual testing |
+| Performance regression | Low | Medium | Benchmark before/after |
+| Async refactoring breaks callers | Low | High | Update all callers in same PR |
+| Backup file incompatibility | Very Low | High | Test with existing backups |
+
+## Conclusion
+
+jszip is the clear choice for replacing adm-zip. The migration requires:
+
+1. Update `package.json` dependencies
+2. Refactor 7 functions from sync to async in `backup.ts`
+3. Update 1 function in `storage.ts`
+4. Update any CLI commands or library exports that call these functions
+5. Add tests for backup operations
+6. Verify backwards compatibility with existing backup files

--- a/specs/007-replace-adm-zip/spec.md
+++ b/specs/007-replace-adm-zip/spec.md
@@ -1,0 +1,113 @@
+# Feature Specification: Replace adm-zip with ESM-Compatible Alternative
+
+**Feature Branch**: `007-replace-adm-zip`
+**Created**: 2026-01-03
+**Status**: Draft
+**Input**: GitHub Issue #8 - adm-zip dynamic require breaks ESM bundling on Node.js v24+
+
+## User Scenarios & Testing
+
+### User Story 1 - Downstream Package ESM Bundling (Priority: P1)
+
+As a developer building an application that depends on cursor-history and bundles it for distribution (like cursor-history-mcp), I want the library to work when bundled as ESM format so that I can distribute modern ESM packages that work on Node.js v24+.
+
+**Why this priority**: This is the core problem reported in the issue. Without this, downstream packages cannot use ESM output format on Node.js v24+, forcing them to use CommonJS which contradicts modern ESM-first development practices.
+
+**Independent Test**: Can be fully tested by bundling cursor-history into an ESM package using tsup/esbuild and running it on Node.js v24+. Success means no "Dynamic require of 'fs' is not supported" errors.
+
+**Acceptance Scenarios**:
+
+1. **Given** a downstream package that depends on cursor-history with `noExternal: [/.*/]` bundler config, **When** bundled as ESM format and executed on Node.js v24+, **Then** all backup-related operations work without dynamic require errors.
+
+2. **Given** cursor-history is imported as `import { createBackup } from 'cursor-history'`, **When** the createBackup function is called in an ESM context, **Then** the backup zip file is created successfully.
+
+---
+
+### User Story 2 - Existing Backup Functionality Preservation (Priority: P1)
+
+As an existing cursor-history user, I want all backup operations (create, restore, validate, list) to continue working exactly as before so that my existing workflows are not disrupted.
+
+**Why this priority**: Equal priority to P1 because breaking existing functionality would be unacceptable. The migration must be transparent to users.
+
+**Independent Test**: Can be fully tested by running the existing test suite and manually testing all backup commands (`cursor-history backup`, restore, validate, list).
+
+**Acceptance Scenarios**:
+
+1. **Given** a Cursor data directory with chat history, **When** I run `cursor-history backup`, **Then** a valid backup zip file is created with manifest.json and all database files.
+
+2. **Given** a valid backup zip file, **When** I run `cursor-history restore <backup-file>`, **Then** all files are extracted to the correct locations with verified checksums.
+
+3. **Given** a backup zip file, **When** I run `cursor-history backup validate <backup-file>`, **Then** the manifest is read and all file checksums are verified correctly.
+
+4. **Given** a backup directory, **When** I run `cursor-history backup list`, **Then** all zip files are enumerated with their manifest information.
+
+---
+
+### User Story 3 - Backup Data Source Operations (Priority: P2)
+
+As a user browsing history from a backup file, I want to list and view sessions from backup files so that I can access historical data without restoring.
+
+**Why this priority**: Lower priority than core backup operations but still essential for the complete feature set. Uses zip reading functionality.
+
+**Independent Test**: Can be tested by running `cursor-history list --backup <file>` and `cursor-history show 1 --backup <file>` against a backup archive.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid backup zip file, **When** I run `cursor-history list --backup <file>`, **Then** all sessions from workspace databases inside the backup are listed.
+
+2. **Given** a valid backup zip file, **When** I run `cursor-history show 1 --backup <file>`, **Then** the session content is displayed correctly from the backup.
+
+---
+
+### Edge Cases
+
+- What happens when the new library encounters a corrupted zip file? Should return meaningful error message, not crash.
+- What happens when a zip file created by the old adm-zip library is read by the new library? Must be fully backwards compatible.
+- What happens when reading very large backup files (>1GB)? Should handle memory efficiently without exhausting heap.
+- What happens when a file path in the zip uses Windows-style separators on Unix or vice versa? Cross-platform path handling must work correctly.
+- What happens when concurrent backup operations attempt to write to the same output file? Should fail gracefully with clear error.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: System MUST replace adm-zip with an ESM-compatible zip library that does not use dynamic require() calls
+- **FR-002**: System MUST support creating zip archives with the same file structure as before (manifest.json, database files in nested directories)
+- **FR-003**: System MUST support reading/extracting files from zip archives by path
+- **FR-004**: System MUST support adding files to zip archives from local filesystem paths
+- **FR-005**: System MUST support adding files to zip archives from Buffer content
+- **FR-006**: System MUST support writing complete zip archives to disk
+- **FR-007**: System MUST handle cross-platform path separators in zip entries (forward slashes inside zip, platform-specific outside)
+- **FR-008**: System MUST read zip archives created by the previous adm-zip implementation (backwards compatibility)
+- **FR-009**: Backup creation MUST produce identical zip structure to current implementation
+- **FR-010**: System MUST work in both ESM and CommonJS module contexts
+
+### Key Entities
+
+- **Backup Archive**: A zip file containing manifest.json and database files (state.vscdb) in directory structure mirroring Cursor's storage layout
+- **Manifest**: JSON file at zip root describing backup contents including file paths, checksums, creation timestamp, and statistics
+- **Database Files**: SQLite files stored at paths like `globalStorage/state.vscdb` and `workspaceStorage/{id}/state.vscdb`
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: All existing backup-related tests pass without modification to test logic (import changes allowed)
+- **SC-002**: Downstream packages can bundle cursor-history as ESM and execute on Node.js v24+ without dynamic require errors
+- **SC-003**: Backup files created by the new implementation can be read by cursor-history versions using adm-zip (forwards compatibility)
+- **SC-004**: Backup files created by previous adm-zip versions can be read by the new implementation (backwards compatibility)
+- **SC-005**: No increase in backup creation time beyond 10% for typical backup sizes (under 100MB)
+
+## Assumptions
+
+- jszip is selected as the replacement library based on the issue recommendation (pure JavaScript, actively maintained, ESM-compatible)
+- jszip's Promise-based API is acceptable; synchronous operations in current code will be converted to async where needed
+- The backup.ts and storage.ts files are the only files requiring changes
+- The existing test coverage for backup operations is sufficient to validate the migration
+
+## Out of Scope
+
+- Changing the backup file format or manifest structure
+- Adding new backup features beyond what currently exists
+- Supporting additional zip libraries or making the zip library pluggable
+- Performance optimizations beyond maintaining current performance levels

--- a/specs/007-replace-adm-zip/tasks.md
+++ b/specs/007-replace-adm-zip/tasks.md
@@ -1,0 +1,180 @@
+# Tasks: Replace adm-zip with ESM-Compatible Alternative
+
+**Input**: Design documents from `/specs/007-replace-adm-zip/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, quickstart.md
+
+**Tests**: No tests explicitly requested in the specification. Manual testing via CLI commands is specified.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Single project**: `src/`, `tests/` at repository root
+- Paths based on plan.md structure
+
+---
+
+## Phase 1: Setup (Dependency Changes)
+
+**Purpose**: Update project dependencies to replace adm-zip with jszip
+
+- [ ] T001 Remove adm-zip and @types/adm-zip from package.json
+- [ ] T002 Add jszip ^3.10.1 to dependencies in package.json
+- [ ] T003 Run npm install to update node_modules and package-lock.json
+- [ ] T004 Verify build succeeds with `npm run build` after dependency change
+
+---
+
+## Phase 2: Foundational (Core Async Refactoring)
+
+**Purpose**: Convert core backup functions from sync to async - MUST complete before user story implementation
+
+**⚠️ CRITICAL**: These changes affect all backup-related functionality
+
+- [ ] T005 Update import statement in src/core/backup.ts: replace `import AdmZip from 'adm-zip'` with `import JSZip from 'jszip'` and add `import { readFile, writeFile } from 'node:fs/promises'`
+- [ ] T006 Update import statement in src/core/storage.ts: replace `import AdmZip from 'adm-zip'` with `import JSZip from 'jszip'` and add `import { readFile } from 'node:fs/promises'`
+- [ ] T007 Convert `readBackupManifest()` to async in src/core/backup.ts: change signature to `async function`, use `await readFile()` and `JSZip.loadAsync()`, return `Promise<BackupManifest | null>`
+- [ ] T008 Convert `openBackupDatabase()` to async in src/core/backup.ts: change signature to `async function`, use `await readFile()` and `JSZip.loadAsync()`, extract file with `await zip.file(dbPath)?.async('nodebuffer')`, return `Promise<DatabaseInterface>`
+- [ ] T009 Convert `validateBackup()` to async in src/core/backup.ts: change signature to `async function`, use async zip loading and file reading, return `Promise<BackupValidation>`
+- [ ] T010 Convert `restoreBackup()` to async in src/core/backup.ts: change signature to `async function`, use async zip loading and extraction, return `Promise<RestoreResult>`
+- [ ] T011 Convert `listBackups()` to async in src/core/backup.ts: change signature to `async function`, await `readBackupManifest()` calls, return `Promise<BackupInfo[]>`
+- [ ] T012 Convert `readWorkspaceJsonFromBackup()` to async in src/core/storage.ts: change signature to `async function`, use `await readFile()` and `JSZip.loadAsync()`, return `Promise<string | null>`
+
+**Checkpoint**: Core async infrastructure complete - user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 & 2 - Backup Create/Restore (Priority: P1) 🎯 MVP
+
+**Goal**: Replace adm-zip usage in createBackup() and restoreBackup() so backup operations work with jszip
+
+**Independent Test**: Run `cursor-history backup` to create a backup, then `cursor-history restore <file>` to restore it
+
+### Implementation for User Story 1 & 2
+
+- [ ] T013 [US1] Refactor zip creation in `createBackup()` in src/core/backup.ts: replace `new AdmZip()` with `new JSZip()`, use `zip.file(path, content)` instead of `addLocalFile/addFile`
+- [ ] T014 [US1] Refactor zip writing in `createBackup()` in src/core/backup.ts: replace `zip.writeZip(outputPath)` with `const content = await zip.generateAsync({type: 'nodebuffer'}); await writeFile(outputPath, content)`
+- [ ] T015 [US2] Refactor zip reading in `restoreBackup()` in src/core/backup.ts: replace `new AdmZip(backupPath)` with `const data = await readFile(backupPath); const zip = await JSZip.loadAsync(data)`
+- [ ] T016 [US2] Refactor file extraction in `restoreBackup()` in src/core/backup.ts: replace `zip.readFile(path)` with `await zip.file(path)?.async('nodebuffer')`
+- [ ] T017 [US2] Update library wrapper `restoreBackup()` in src/lib/backup.ts: change to `async function`, update return type to `Promise<RestoreResult>`
+- [ ] T018 [US2] Update library wrapper `validateBackup()` in src/lib/backup.ts: change to `async function`, update return type to `Promise<BackupValidation>`
+- [ ] T019 [US2] Update library wrapper `listBackups()` in src/lib/backup.ts: change to `async function`, update return type to `Promise<BackupInfo[]>`
+- [ ] T020 [US2] Update CLI command callers in src/cli/commands/backup.ts: add `await` to `restoreBackup()`, `validateBackup()`, `listBackups()` calls
+
+**Checkpoint**: Backup create and restore should work - test with `cursor-history backup` and `cursor-history restore`
+
+---
+
+## Phase 4: User Story 3 - Backup Data Source (Priority: P2)
+
+**Goal**: Enable reading sessions from backup files with jszip
+
+**Independent Test**: Run `cursor-history list --backup <file>` and `cursor-history show 1 --backup <file>`
+
+### Implementation for User Story 3
+
+- [ ] T021 [US3] Refactor `readWorkspaceJsonFromBackup()` implementation in src/core/storage.ts: use `await readFile()` and `JSZip.loadAsync()` to read zip, extract workspace.json with `await zip.file(path)?.async('nodebuffer')`
+- [ ] T022 [US3] Update `findWorkspacesFromBackup()` in src/core/storage.ts: await the now-async `readWorkspaceJsonFromBackup()` call
+- [ ] T023 [US3] Update callers of `openBackupDatabase()` in src/core/storage.ts: add `await` to all calls (in `findWorkspacesFromBackup`, `listSessions`, `getSession`)
+
+**Checkpoint**: Reading from backup files should work - test with `cursor-history list --backup <file>`
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, validation, and cleanup
+
+- [ ] T024 [P] Update module docstring in src/core/backup.ts: change "Zip creation/extraction using adm-zip" to "Zip creation/extraction using jszip"
+- [ ] T025 [P] Run TypeScript type check with `npm run typecheck` to verify all async/await types are correct
+- [ ] T026 [P] Run linter with `npm run lint` to verify code style
+- [ ] T027 Build project with `npm run build` and verify no errors
+- [ ] T028 Manual test: Create backup with `node dist/cli/index.js backup`
+- [ ] T029 Manual test: List backups with `node dist/cli/index.js backup list`
+- [ ] T030 Manual test: Validate backup with `node dist/cli/index.js backup validate <file>`
+- [ ] T031 Manual test: Restore backup with `node dist/cli/index.js backup restore <file> --force`
+- [ ] T032 Manual test: List sessions from backup with `node dist/cli/index.js list --backup <file>`
+- [ ] T033 Manual test: Show session from backup with `node dist/cli/index.js show 1 --backup <file>`
+- [ ] T034 [P] Verify backwards compatibility: read a backup file created with adm-zip version (if available)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - BLOCKS all user stories
+- **User Stories 1 & 2 (Phase 3)**: Depends on Foundational phase completion
+- **User Story 3 (Phase 4)**: Depends on Foundational phase completion, can run parallel to Phase 3
+- **Polish (Phase 5)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 & 2 (P1)**: Can start after Foundational (Phase 2) - Core backup/restore
+- **User Story 3 (P2)**: Can start after Foundational (Phase 2) - Can run in parallel with US1/2 if different developer
+
+### Within Each Phase
+
+- T001-T004: Sequential (dependency changes must be in order)
+- T005-T012: T005-T006 parallel, then T007-T012 can be parallel (different functions)
+- T013-T020: T013-T014 sequential (same function), T015-T016 sequential (same function), T017-T020 can be parallel
+- T021-T023: Sequential within storage.ts
+- T024-T034: T024-T027 parallel, T028-T034 sequential (manual tests depend on build)
+
+### Parallel Opportunities
+
+```bash
+# Phase 2 - Foundation (after imports updated):
+Task: T007 "Convert readBackupManifest() to async"
+Task: T008 "Convert openBackupDatabase() to async"
+Task: T009 "Convert validateBackup() to async"
+Task: T010 "Convert restoreBackup() to async"
+Task: T011 "Convert listBackups() to async"
+
+# Phase 3 - Library wrappers:
+Task: T017 "Update restoreBackup wrapper"
+Task: T018 "Update validateBackup wrapper"
+Task: T019 "Update listBackups wrapper"
+
+# Phase 5 - Polish:
+Task: T024 "Update docstring"
+Task: T025 "Run typecheck"
+Task: T026 "Run linter"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Stories 1 & 2)
+
+1. Complete Phase 1: Setup (dependency swap)
+2. Complete Phase 2: Foundational (async conversions)
+3. Complete Phase 3: User Stories 1 & 2 (backup create/restore)
+4. **STOP and VALIDATE**: Test `cursor-history backup` and `cursor-history restore`
+5. If working, this is a deployable MVP
+
+### Incremental Delivery
+
+1. Complete Setup + Foundational → Build passes
+2. Add User Stories 1 & 2 → Test backup/restore → Can release
+3. Add User Story 3 → Test backup reading → Full feature complete
+4. Polish phase → Documentation and validation complete
+
+---
+
+## Notes
+
+- All adm-zip usages are in 2 files: backup.ts (6 instances) and storage.ts (1 instance)
+- jszip is Promise-based, so all zip operations become async
+- The library API wrappers in src/lib/backup.ts must also become async
+- CLI commands in src/cli/commands/backup.ts need await for the now-async functions
+- Backwards compatibility: jszip reads standard ZIP format, should read old adm-zip backups
+- No new files created - this is a refactoring task

--- a/src/cli/commands/export.ts
+++ b/src/cli/commands/export.ts
@@ -51,7 +51,7 @@ export function registerExportCommand(program: Command): void {
 
         // T037: Validate backup if exporting from backup
         if (backupPath) {
-          const validation = validateBackup(backupPath);
+          const validation = await validateBackup(backupPath);
           if (validation.status === 'invalid') {
             if (useJson) {
               console.log(JSON.stringify({ error: 'Invalid backup', errors: validation.errors }));

--- a/src/cli/commands/list-backups.ts
+++ b/src/cli/commands/list-backups.ts
@@ -131,7 +131,7 @@ export function registerListBackupsCommand(program: Command): void {
     .alias('backups')
     .description('List available backup files')
     .option('-d, --directory <path>', 'Directory to scan (default: ~/cursor-history-backups)')
-    .action((options: ListBackupsCommandOptions, command: Command) => {
+    .action(async (options: ListBackupsCommandOptions, command: Command) => {
       const globalOptions = command.parent?.opts() as { json?: boolean };
       const useJson = options.json ?? globalOptions?.json ?? false;
 
@@ -160,7 +160,7 @@ export function registerListBackupsCommand(program: Command): void {
         }
 
         // List backups
-        const backups = listBackups(directory);
+        const backups = await listBackups(directory);
 
         // T063: Handle no backups found
         if (backups.length === 0) {

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -54,7 +54,7 @@ export function registerListCommand(program: Command): void {
 
       // T034: Validate backup if reading from backup
       if (backupPath) {
-        const validation = validateBackup(backupPath);
+        const validation = await validateBackup(backupPath);
         if (validation.status === 'invalid') {
           if (useJson) {
             console.log(JSON.stringify({ error: 'Invalid backup', errors: validation.errors }));

--- a/src/cli/commands/restore.ts
+++ b/src/cli/commands/restore.ts
@@ -133,7 +133,7 @@ export function registerRestoreCommand(program: Command): void {
         }
 
         // T052: Validate backup before attempting restore
-        const validation = validateBackup(backupPath);
+        const validation = await validateBackup(backupPath);
         if (validation.status === 'invalid') {
           if (useJson) {
             console.log(JSON.stringify({
@@ -164,7 +164,7 @@ export function registerRestoreCommand(program: Command): void {
         const onProgress = useJson ? undefined : displayProgress;
 
         // Perform restore
-        const result = restoreBackup({
+        const result = await restoreBackup({
           backupPath,
           targetPath,
           force: options.force ?? false,

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -45,7 +45,7 @@ export function registerSearchCommand(program: Command): void {
 
       // T036: Validate backup if searching from backup
       if (backupPath) {
-        const validation = validateBackup(backupPath);
+        const validation = await validateBackup(backupPath);
         if (validation.status === 'invalid') {
           if (useJson) {
             console.log(JSON.stringify({ error: 'Invalid backup', errors: validation.errors }));

--- a/src/cli/commands/show.ts
+++ b/src/cli/commands/show.ts
@@ -46,7 +46,7 @@ export function registerShowCommand(program: Command): void {
 
       // T035: Validate backup if reading from backup
       if (backupPath) {
-        const validation = validateBackup(backupPath);
+        const validation = await validateBackup(backupPath);
         if (validation.status === 'invalid') {
           if (useJson) {
             console.log(JSON.stringify({ error: 'Invalid backup', errors: validation.errors }));

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -54,19 +54,19 @@ export async function createBackup(config?: BackupConfig): Promise<BackupResult>
  * Restore Cursor chat history from a backup file.
  *
  * @param config - Restore configuration (backupPath required)
- * @returns Restore result
+ * @returns Promise resolving to restore result
  *
  * @example
  * ```typescript
  * import { restoreBackup } from 'cursor-history';
  *
- * const result = restoreBackup({
+ * const result = await restoreBackup({
  *   backupPath: '/path/to/backup.zip',
  *   force: true
  * });
  * ```
  */
-export function restoreBackup(config: RestoreConfig): RestoreResult {
+export async function restoreBackup(config: RestoreConfig): Promise<RestoreResult> {
   return coreRestoreBackup(config);
 }
 
@@ -74,19 +74,19 @@ export function restoreBackup(config: RestoreConfig): RestoreResult {
  * Validate a backup file's integrity without restoring.
  *
  * @param backupPath - Path to backup zip file
- * @returns Validation result with status and details
+ * @returns Promise resolving to validation result with status and details
  *
  * @example
  * ```typescript
  * import { validateBackup } from 'cursor-history';
  *
- * const validation = validateBackup('/path/to/backup.zip');
+ * const validation = await validateBackup('/path/to/backup.zip');
  * if (validation.status === 'valid') {
  *   console.log('Backup is valid');
  * }
  * ```
  */
-export function validateBackup(backupPath: string): BackupValidation {
+export async function validateBackup(backupPath: string): Promise<BackupValidation> {
   return coreValidateBackup(backupPath);
 }
 
@@ -94,19 +94,19 @@ export function validateBackup(backupPath: string): BackupValidation {
  * List available backup files in a directory.
  *
  * @param directory - Directory to scan (default: ~/cursor-history-backups)
- * @returns Array of backup info objects
+ * @returns Promise resolving to array of backup info objects
  *
  * @example
  * ```typescript
  * import { listBackups } from 'cursor-history';
  *
- * const backups = listBackups();
+ * const backups = await listBackups();
  * for (const backup of backups) {
  *   console.log(`${backup.filename}: ${backup.manifest?.stats.sessionCount} sessions`);
  * }
  * ```
  */
-export function listBackups(directory?: string): BackupInfo[] {
+export async function listBackups(directory?: string): Promise<BackupInfo[]> {
   return coreListBackups(directory);
 }
 


### PR DESCRIPTION
Replace adm-zip (which uses dynamic require()) with jszip to fix ESM bundling issues on Node.js v24+.

Changes:
- Replace adm-zip dependency with jszip@^3.10.1
- Convert sync zip operations to async/await pattern
- Update backup.ts: readBackupManifest, openBackupDatabase, validateBackup, restoreBackup, listBackups now async
- Update storage.ts: readWorkspaceJsonFromBackup async, findWorkspacesFromBackup uses await for backup operations
- Update lib/backup.ts: async wrappers for library API
- Update CLI commands to await async backup functions
- Add speckit documentation for the migration
- Bump version to 0.9.2

Fixes #8