### PR TITLE
fix(migration): preserve and recover session visibility across workspace moves

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cursor-history",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cursor-history",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cursor-history",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "The ultimate CLI tool and library to browse, search, export, migrate, and backup your Cursor AI chat history",
   "type": "module",
   "main": "dist/lib/index.js",

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -16,6 +16,7 @@ import {
   openDatabaseReadWrite,
   getComposerData,
   updateComposerData,
+  getWorkspaceLinkedComposerIds,
 } from './storage.js';
 import { normalizePath, pathsEqual } from '../lib/platform.js';
 import {
@@ -322,7 +323,9 @@ function toFileUri(path: string): string {
 
 function toFileUriPath(workspacePath: string): string {
   try {
-    return new URL(toFileUri(workspacePath)).pathname;
+    // In the VS Code URI model `uri.path` is the DECODED path (it must match
+    // fsPath); only `external`/`workspaceUri` carry percent-encoding.
+    return decodeURIComponent(new URL(toFileUri(workspacePath)).pathname);
   } catch {
     return normalizePath(workspacePath);
   }
@@ -359,6 +362,32 @@ function updateComposerWorkspaceMetadata(
       scheme: 'file',
     },
   };
+}
+
+function composerExistsInGlobalStorage(composerId: string): boolean {
+  const globalDbPath = join(getGlobalStoragePath(), 'state.vscdb');
+  if (!existsSync(globalDbPath)) {
+    return false;
+  }
+
+  const db = new BetterSqlite3(globalDbPath, { readonly: true });
+  try {
+    const composerRow = db
+      .prepare('SELECT 1 FROM cursorDiskKV WHERE key = ? LIMIT 1')
+      .get(`composerData:${composerId}`);
+    if (composerRow) {
+      return true;
+    }
+
+    const bubbleRow = db
+      .prepare('SELECT 1 FROM cursorDiskKV WHERE key LIKE ? LIMIT 1')
+      .get(`bubbleId:${composerId}:%`);
+    return Boolean(bubbleRow);
+  } catch {
+    return false;
+  } finally {
+    db.close();
+  }
 }
 
 function updateComposerWorkspaceInGlobalStorage(
@@ -689,27 +718,32 @@ export async function migrateSession(
         throw new Error('Source workspace has no composer data');
       }
 
-      // Find the session in source data
+      // Find the session in source data. It may live only in global storage
+      // (linked to the workspace via workspaceIdentifier), in which case there is
+      // no workspace-DB composer entry to remove.
       const sessionIndex = sourceResult.composers.findIndex((s) => s.composerId === sessionId);
-      if (sessionIndex === -1) {
+      const isGlobalOnly = sessionIndex === -1;
+      if (isGlobalOnly && !composerExistsInGlobalStorage(sessionId)) {
         throw new SessionNotFoundError(sessionId);
       }
 
-      const sessionToMigrate = sourceResult.composers[sessionIndex]!;
-      const hydratedSession = hydrateComposerFromGlobalStorage(
-        sessionToMigrate as Record<string, unknown>,
-        sessionId
-      );
+      const sessionToMigrate: Record<string, unknown> =
+        sessionIndex >= 0
+          ? (sourceResult.composers[sessionIndex]! as Record<string, unknown>)
+          : { composerId: sessionId };
+      const hydratedSession = hydrateComposerFromGlobalStorage(sessionToMigrate, sessionId);
 
       if (mode === 'move') {
-        // Remove from source
-        const newSourceComposers = sourceResult.composers.filter((_, i) => i !== sessionIndex);
-        updateComposerData(
-          sourceDb,
-          newSourceComposers,
-          sourceResult.isNewFormat,
-          sourceResult.rawData
-        );
+        // Remove from source (skip when the session is only in global storage)
+        if (!isGlobalOnly) {
+          const newSourceComposers = sourceResult.composers.filter((_, i) => i !== sessionIndex);
+          updateComposerData(
+            sourceDb,
+            newSourceComposers,
+            sourceResult.isNewFormat,
+            sourceResult.rawData
+          );
+        }
 
         // Add to destination
         const destComposers = destResult ? destResult.composers : [];
@@ -878,7 +912,24 @@ export async function migrateWorkspace(
   const sourceResult = getComposerData(sourceDb);
   sourceDb.close();
 
-  if (!sourceResult || sourceResult.composers.length === 0) {
+  // Extract session IDs from the workspace composer list, then union in any
+  // sessions discoverable only through global storage (linked to this workspace
+  // via workspaceIdentifier/workspaceUri) so migration covers everything `list`
+  // shows for the source workspace.
+  const sessionIds: string[] = sourceResult
+    ? sourceResult.composers
+        .map((s) => s.composerId)
+        .filter((id): id is string => typeof id === 'string')
+    : [];
+  const sessionIdSet = new Set(sessionIds);
+  for (const linkedId of await getWorkspaceLinkedComposerIds(sourceInfo.workspace)) {
+    if (!sessionIdSet.has(linkedId)) {
+      sessionIdSet.add(linkedId);
+      sessionIds.push(linkedId);
+    }
+  }
+
+  if (sessionIds.length === 0) {
     throw new NoSessionsFoundError(normalizedSource);
   }
 
@@ -891,15 +942,6 @@ export async function migrateWorkspace(
     if (destResult && destResult.composers.length > 0) {
       throw new DestinationHasSessionsError(normalizedDest, destResult.composers.length);
     }
-  }
-
-  // Extract session IDs
-  const sessionIds = sourceResult.composers
-    .map((s) => s.composerId)
-    .filter((id): id is string => typeof id === 'string');
-
-  if (sessionIds.length === 0) {
-    throw new NoSessionsFoundError(normalizedSource);
   }
 
   // Migrate all sessions

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -922,7 +922,7 @@ export async function migrateWorkspace(
         .filter((id): id is string => typeof id === 'string')
     : [];
   const sessionIdSet = new Set(sessionIds);
-  for (const linkedId of await getWorkspaceLinkedComposerIds(sourceInfo.workspace)) {
+  for (const linkedId of await getWorkspaceLinkedComposerIds(sourceInfo.workspace, dataPath)) {
     if (!sessionIdSet.has(linkedId)) {
       sessionIdSet.add(linkedId);
       sessionIds.push(linkedId);

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -8,6 +8,7 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
+import { pathToFileURL } from 'node:url';
 import BetterSqlite3 from 'better-sqlite3';
 import {
   findWorkspaceForSession,
@@ -309,10 +310,62 @@ function isNestedPath(source: string, destination: string): boolean {
 
 function toFileUri(path: string): string {
   const normalized = normalizePath(path);
-  return `file://${encodeURI(normalized)}`;
+  const windowsDrivePath = normalized.match(/^([A-Za-z]):[\\/](.*)$/);
+  if (windowsDrivePath) {
+    const drive = windowsDrivePath[1]!.toLowerCase();
+    const rest = windowsDrivePath[2]!.replace(/\\/g, '/').split('/').map(encodeURIComponent).join('/');
+    return `file:///${drive}:/${rest}`;
+  }
+
+  return pathToFileURL(normalized).href;
 }
 
-function updateComposerWorkspaceInGlobalStorage(composerId: string, workspacePath: string): void {
+function toFileUriPath(workspacePath: string): string {
+  try {
+    return new URL(toFileUri(workspacePath)).pathname;
+  } catch {
+    return normalizePath(workspacePath);
+  }
+}
+
+function updateComposerWorkspaceMetadata(
+  composerData: Record<string, unknown>,
+  workspacePath: string,
+  workspaceId?: string
+): void {
+  const normalizedPath = normalizePath(workspacePath);
+  const fileUri = toFileUri(normalizedPath);
+  composerData['workspaceUri'] = fileUri;
+
+  const existingIdentifier =
+    composerData['workspaceIdentifier'] &&
+    typeof composerData['workspaceIdentifier'] === 'object' &&
+    !Array.isArray(composerData['workspaceIdentifier'])
+      ? (composerData['workspaceIdentifier'] as Record<string, unknown>)
+      : {};
+  const existingUri =
+    existingIdentifier['uri'] && typeof existingIdentifier['uri'] === 'object'
+      ? (existingIdentifier['uri'] as Record<string, unknown>)
+      : {};
+
+  composerData['workspaceIdentifier'] = {
+    ...existingIdentifier,
+    ...(workspaceId ? { id: workspaceId } : {}),
+    uri: {
+      ...existingUri,
+      fsPath: normalizedPath,
+      external: fileUri,
+      path: toFileUriPath(normalizedPath),
+      scheme: 'file',
+    },
+  };
+}
+
+function updateComposerWorkspaceInGlobalStorage(
+  composerId: string,
+  workspacePath: string,
+  workspaceId?: string
+): void {
   const globalDbPath = join(getGlobalStoragePath(), 'state.vscdb');
   if (!existsSync(globalDbPath)) {
     return;
@@ -328,31 +381,12 @@ function updateComposerWorkspaceInGlobalStorage(composerId: string, workspacePat
     }
 
     const composerData = JSON.parse(composerDataRow.value) as Record<string, unknown>;
-    composerData.workspaceUri = toFileUri(workspacePath);
+    updateComposerWorkspaceMetadata(composerData, workspacePath, workspaceId);
 
     db.prepare('UPDATE cursorDiskKV SET value = ? WHERE key = ?').run(
       JSON.stringify(composerData),
       `composerData:${composerId}`
     );
-  } finally {
-    db.close();
-  }
-}
-
-function getComposerBubbleCountInGlobalStorage(composerId: string): number {
-  const globalDbPath = join(getGlobalStoragePath(), 'state.vscdb');
-  if (!existsSync(globalDbPath)) {
-    return 0;
-  }
-
-  const db = new BetterSqlite3(globalDbPath, { readonly: true });
-  try {
-    const row = db
-      .prepare('SELECT COUNT(*) as count FROM cursorDiskKV WHERE key LIKE ?')
-      .get(`bubbleId:${composerId}:%`) as { count: number } | undefined;
-    return row?.count ?? 0;
-  } catch {
-    return 0;
   } finally {
     db.close();
   }
@@ -378,19 +412,21 @@ function hydrateComposerFromGlobalStorage(
 
     const globalComposer = JSON.parse(row.value) as {
       name?: string;
-      createdAt?: number;
-      updatedAt?: number;
+      createdAt?: number | string;
+      updatedAt?: number | string;
+      lastUpdatedAt?: number | string;
       unifiedMode?: string;
     };
+    const lastUpdatedAt = globalComposer.lastUpdatedAt ?? globalComposer.updatedAt;
 
     return {
       ...composer,
       composerId,
       ...(typeof globalComposer.name === 'string' ? { name: globalComposer.name } : {}),
-      ...(typeof globalComposer.createdAt === 'number' ? { createdAt: globalComposer.createdAt } : {}),
-      ...(typeof globalComposer.updatedAt === 'number'
-        ? { lastUpdatedAt: globalComposer.updatedAt }
+      ...(globalComposer.createdAt !== undefined && globalComposer.createdAt !== null
+        ? { createdAt: globalComposer.createdAt }
         : {}),
+      ...(lastUpdatedAt !== undefined && lastUpdatedAt !== null ? { lastUpdatedAt } : {}),
       ...(typeof globalComposer.unifiedMode === 'string'
         ? { unifiedMode: globalComposer.unifiedMode }
         : {}),
@@ -419,6 +455,7 @@ function copyBubbleDataInGlobalStorage(
   newComposerId: string,
   sourceWorkspace: string,
   destWorkspace: string,
+  destWorkspaceId?: string,
   debug: boolean = false
 ): Map<string, string> {
   const globalDbPath = join(getGlobalStoragePath(), 'state.vscdb');
@@ -445,7 +482,7 @@ function copyBubbleDataInGlobalStorage(
 
       // Update composerId in the data
       composerData.composerId = newComposerId;
-      composerData.workspaceUri = toFileUri(destWorkspace);
+      updateComposerWorkspaceMetadata(composerData, destWorkspace, destWorkspaceId);
 
       // We'll update fullConversationHeadersOnly after generating new bubble IDs
       const oldBubbleHeaders = composerData.fullConversationHeadersOnly || [];
@@ -689,7 +726,7 @@ export async function migrateSession(
 
         // T010-T012: Update file paths in global storage bubble data for move mode
         updateBubblePathsInGlobalStorage(sessionId, sourceWorkspace, normalizedDest, debug);
-        updateComposerWorkspaceInGlobalStorage(sessionId, normalizedDest);
+        updateComposerWorkspaceInGlobalStorage(sessionId, normalizedDest, destInfo.workspace?.id);
 
         return {
           success: true,
@@ -712,6 +749,7 @@ export async function migrateSession(
           newSessionId,
           sourceWorkspace,
           normalizedDest,
+          destInfo.workspace?.id,
           debug
         );
 
@@ -856,21 +894,9 @@ export async function migrateWorkspace(
   }
 
   // Extract session IDs
-  let sessionIds = sourceResult.composers
+  const sessionIds = sourceResult.composers
     .map((s) => s.composerId)
     .filter((id): id is string => typeof id === 'string');
-
-  // If workspace data is header-only, keep only sessions that actually have global bubbles.
-  const isHeaderOnly = sourceResult.composers.every((composer) => {
-    const keys = Object.keys(composer).filter((key) => key !== 'composerId');
-    return keys.length === 0;
-  });
-  if (isHeaderOnly) {
-    const withBubbles = sessionIds.filter((sessionId) => getComposerBubbleCountInGlobalStorage(sessionId) > 0);
-    if (withBubbles.length > 0) {
-      sessionIds = withBubbles;
-    }
-  }
 
   if (sessionIds.length === 0) {
     throw new NoSessionsFoundError(normalizedSource);

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -7,7 +7,6 @@
 
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
-import { homedir } from 'node:os';
 import { pathToFileURL } from 'node:url';
 import BetterSqlite3 from 'better-sqlite3';
 import {
@@ -18,7 +17,7 @@ import {
   updateComposerData,
   getWorkspaceLinkedComposerIds,
 } from './storage.js';
-import { normalizePath, pathsEqual } from '../lib/platform.js';
+import { getGlobalStoragePath, normalizePath, pathsEqual } from '../lib/platform.js';
 import {
   SessionNotFoundError,
   WorkspaceNotFoundError,
@@ -44,27 +43,6 @@ function generateSessionId(): string {
     const v = c === 'x' ? r : (r & 0x3) | 0x8;
     return v.toString(16);
   });
-}
-
-/**
- * Get the global Cursor storage path
- */
-function getGlobalStoragePath(): string {
-  const platform = process.platform;
-  const home = homedir();
-
-  if (platform === 'win32') {
-    return join(
-      process.env['APPDATA'] ?? join(home, 'AppData', 'Roaming'),
-      'Cursor',
-      'User',
-      'globalStorage'
-    );
-  } else if (platform === 'darwin') {
-    return join(home, 'Library', 'Application Support', 'Cursor', 'User', 'globalStorage');
-  } else {
-    return join(home, '.config', 'Cursor', 'User', 'globalStorage');
-  }
 }
 
 // ============================================================================
@@ -364,8 +342,8 @@ function updateComposerWorkspaceMetadata(
   };
 }
 
-function composerExistsInGlobalStorage(composerId: string): boolean {
-  const globalDbPath = join(getGlobalStoragePath(), 'state.vscdb');
+function composerExistsInGlobalStorage(composerId: string, dataPath?: string): boolean {
+  const globalDbPath = join(getGlobalStoragePath(dataPath), 'state.vscdb');
   if (!existsSync(globalDbPath)) {
     return false;
   }
@@ -393,9 +371,10 @@ function composerExistsInGlobalStorage(composerId: string): boolean {
 function updateComposerWorkspaceInGlobalStorage(
   composerId: string,
   workspacePath: string,
-  workspaceId?: string
+  workspaceId?: string,
+  dataPath?: string
 ): void {
-  const globalDbPath = join(getGlobalStoragePath(), 'state.vscdb');
+  const globalDbPath = join(getGlobalStoragePath(dataPath), 'state.vscdb');
   if (!existsSync(globalDbPath)) {
     return;
   }
@@ -423,9 +402,10 @@ function updateComposerWorkspaceInGlobalStorage(
 
 function hydrateComposerFromGlobalStorage(
   composer: Record<string, unknown>,
-  composerId: string
+  composerId: string,
+  dataPath?: string
 ): Record<string, unknown> {
-  const globalDbPath = join(getGlobalStoragePath(), 'state.vscdb');
+  const globalDbPath = join(getGlobalStoragePath(dataPath), 'state.vscdb');
   if (!existsSync(globalDbPath)) {
     return composer;
   }
@@ -485,9 +465,10 @@ function copyBubbleDataInGlobalStorage(
   sourceWorkspace: string,
   destWorkspace: string,
   destWorkspaceId?: string,
-  debug: boolean = false
+  debug: boolean = false,
+  dataPath?: string
 ): Map<string, string> {
-  const globalDbPath = join(getGlobalStoragePath(), 'state.vscdb');
+  const globalDbPath = join(getGlobalStoragePath(dataPath), 'state.vscdb');
 
   if (!existsSync(globalDbPath)) {
     return new Map();
@@ -596,9 +577,10 @@ function updateBubblePathsInGlobalStorage(
   composerId: string,
   sourceWorkspace: string,
   destWorkspace: string,
-  debug: boolean = false
+  debug: boolean = false,
+  dataPath?: string
 ): void {
-  const globalDbPath = join(getGlobalStoragePath(), 'state.vscdb');
+  const globalDbPath = join(getGlobalStoragePath(dataPath), 'state.vscdb');
 
   if (!existsSync(globalDbPath)) {
     return;
@@ -723,7 +705,7 @@ export async function migrateSession(
       // no workspace-DB composer entry to remove.
       const sessionIndex = sourceResult.composers.findIndex((s) => s.composerId === sessionId);
       const isGlobalOnly = sessionIndex === -1;
-      if (isGlobalOnly && !composerExistsInGlobalStorage(sessionId)) {
+      if (isGlobalOnly && !composerExistsInGlobalStorage(sessionId, dataPath)) {
         throw new SessionNotFoundError(sessionId);
       }
 
@@ -731,7 +713,7 @@ export async function migrateSession(
         sessionIndex >= 0
           ? (sourceResult.composers[sessionIndex]! as Record<string, unknown>)
           : { composerId: sessionId };
-      const hydratedSession = hydrateComposerFromGlobalStorage(sessionToMigrate, sessionId);
+      const hydratedSession = hydrateComposerFromGlobalStorage(sessionToMigrate, sessionId, dataPath);
 
       if (mode === 'move') {
         // Remove from source (skip when the session is only in global storage)
@@ -759,8 +741,13 @@ export async function migrateSession(
         );
 
         // T010-T012: Update file paths in global storage bubble data for move mode
-        updateBubblePathsInGlobalStorage(sessionId, sourceWorkspace, normalizedDest, debug);
-        updateComposerWorkspaceInGlobalStorage(sessionId, normalizedDest, destInfo.workspace?.id);
+        updateBubblePathsInGlobalStorage(sessionId, sourceWorkspace, normalizedDest, debug, dataPath);
+        updateComposerWorkspaceInGlobalStorage(
+          sessionId,
+          normalizedDest,
+          destInfo.workspace?.id,
+          dataPath
+        );
 
         return {
           success: true,
@@ -784,7 +771,8 @@ export async function migrateSession(
           sourceWorkspace,
           normalizedDest,
           destInfo.workspace?.id,
-          debug
+          debug,
+          dataPath
         );
 
         // Deep clone and update the session with new ID

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -307,6 +307,101 @@ function isNestedPath(source: string, destination: string): boolean {
   return normalizedDest.startsWith(normalizedSource + '/');
 }
 
+function toFileUri(path: string): string {
+  const normalized = normalizePath(path);
+  return `file://${encodeURI(normalized)}`;
+}
+
+function updateComposerWorkspaceInGlobalStorage(composerId: string, workspacePath: string): void {
+  const globalDbPath = join(getGlobalStoragePath(), 'state.vscdb');
+  if (!existsSync(globalDbPath)) {
+    return;
+  }
+
+  const db = new BetterSqlite3(globalDbPath, { readonly: false });
+  try {
+    const composerDataRow = db
+      .prepare('SELECT value FROM cursorDiskKV WHERE key = ?')
+      .get(`composerData:${composerId}`) as { value: string } | undefined;
+    if (!composerDataRow?.value) {
+      return;
+    }
+
+    const composerData = JSON.parse(composerDataRow.value) as Record<string, unknown>;
+    composerData.workspaceUri = toFileUri(workspacePath);
+
+    db.prepare('UPDATE cursorDiskKV SET value = ? WHERE key = ?').run(
+      JSON.stringify(composerData),
+      `composerData:${composerId}`
+    );
+  } finally {
+    db.close();
+  }
+}
+
+function getComposerBubbleCountInGlobalStorage(composerId: string): number {
+  const globalDbPath = join(getGlobalStoragePath(), 'state.vscdb');
+  if (!existsSync(globalDbPath)) {
+    return 0;
+  }
+
+  const db = new BetterSqlite3(globalDbPath, { readonly: true });
+  try {
+    const row = db
+      .prepare('SELECT COUNT(*) as count FROM cursorDiskKV WHERE key LIKE ?')
+      .get(`bubbleId:${composerId}:%`) as { count: number } | undefined;
+    return row?.count ?? 0;
+  } catch {
+    return 0;
+  } finally {
+    db.close();
+  }
+}
+
+function hydrateComposerFromGlobalStorage(
+  composer: Record<string, unknown>,
+  composerId: string
+): Record<string, unknown> {
+  const globalDbPath = join(getGlobalStoragePath(), 'state.vscdb');
+  if (!existsSync(globalDbPath)) {
+    return composer;
+  }
+
+  const db = new BetterSqlite3(globalDbPath, { readonly: true });
+  try {
+    const row = db
+      .prepare('SELECT value FROM cursorDiskKV WHERE key = ?')
+      .get(`composerData:${composerId}`) as { value: string } | undefined;
+    if (!row?.value) {
+      return composer;
+    }
+
+    const globalComposer = JSON.parse(row.value) as {
+      name?: string;
+      createdAt?: number;
+      updatedAt?: number;
+      unifiedMode?: string;
+    };
+
+    return {
+      ...composer,
+      composerId,
+      ...(typeof globalComposer.name === 'string' ? { name: globalComposer.name } : {}),
+      ...(typeof globalComposer.createdAt === 'number' ? { createdAt: globalComposer.createdAt } : {}),
+      ...(typeof globalComposer.updatedAt === 'number'
+        ? { lastUpdatedAt: globalComposer.updatedAt }
+        : {}),
+      ...(typeof globalComposer.unifiedMode === 'string'
+        ? { unifiedMode: globalComposer.unifiedMode }
+        : {}),
+    };
+  } catch {
+    return composer;
+  } finally {
+    db.close();
+  }
+}
+
 /**
  * Copy all bubble data for a session in global storage with new IDs.
  * This is required for copy mode to create independent session data.
@@ -350,6 +445,7 @@ function copyBubbleDataInGlobalStorage(
 
       // Update composerId in the data
       composerData.composerId = newComposerId;
+      composerData.workspaceUri = toFileUri(destWorkspace);
 
       // We'll update fullConversationHeadersOnly after generating new bubble IDs
       const oldBubbleHeaders = composerData.fullConversationHeadersOnly || [];
@@ -491,17 +587,22 @@ function updateBubblePathsInGlobalStorage(
  */
 export async function migrateSession(
   sessionId: string,
-  options: Omit<MigrateSessionOptions, 'sessionIds'>
+  options: Omit<MigrateSessionOptions, 'sessionIds'> & { sourceWorkspacePath?: string }
 ): Promise<SessionMigrationResult> {
-  const { destination, mode, dryRun, dataPath, debug = false } = options;
+  const { destination, mode, dryRun, dataPath, debug = false, sourceWorkspacePath } = options;
   // Note: force option is used at the CLI layer for validation, not in core migration
 
   // Normalize destination path
   const normalizedDest = normalizePath(destination);
 
-  // Find source workspace for this session
-  const sourceInfo = await findWorkspaceForSession(sessionId, dataPath);
+  // Find source workspace for this session (or use explicit source workspace in workspace migration mode)
+  const sourceInfo = sourceWorkspacePath
+    ? await findWorkspaceByPath(sourceWorkspacePath, dataPath)
+    : await findWorkspaceForSession(sessionId, dataPath);
   if (!sourceInfo) {
+    if (sourceWorkspacePath) {
+      throw new WorkspaceNotFoundError(sourceWorkspacePath);
+    }
     throw new SessionNotFoundError(sessionId);
   }
 
@@ -558,6 +659,10 @@ export async function migrateSession(
       }
 
       const sessionToMigrate = sourceResult.composers[sessionIndex]!;
+      const hydratedSession = hydrateComposerFromGlobalStorage(
+        sessionToMigrate as Record<string, unknown>,
+        sessionId
+      );
 
       if (mode === 'move') {
         // Remove from source
@@ -571,7 +676,10 @@ export async function migrateSession(
 
         // Add to destination
         const destComposers = destResult ? destResult.composers : [];
-        const newDestComposers = [...destComposers, sessionToMigrate];
+        const newDestComposers = [
+          ...destComposers.filter((composer) => composer.composerId !== sessionId),
+          hydratedSession,
+        ];
         updateComposerData(
           destDb,
           newDestComposers,
@@ -581,6 +689,7 @@ export async function migrateSession(
 
         // T010-T012: Update file paths in global storage bubble data for move mode
         updateBubblePathsInGlobalStorage(sessionId, sourceWorkspace, normalizedDest, debug);
+        updateComposerWorkspaceInGlobalStorage(sessionId, normalizedDest);
 
         return {
           success: true,
@@ -607,7 +716,7 @@ export async function migrateSession(
         );
 
         // Deep clone and update the session with new ID
-        const copiedSession = JSON.parse(JSON.stringify(sessionToMigrate)) as {
+        const copiedSession = JSON.parse(JSON.stringify(hydratedSession)) as {
           composerId?: string;
         };
         copiedSession.composerId = newSessionId;
@@ -747,24 +856,52 @@ export async function migrateWorkspace(
   }
 
   // Extract session IDs
-  const sessionIds = sourceResult.composers
+  let sessionIds = sourceResult.composers
     .map((s) => s.composerId)
     .filter((id): id is string => typeof id === 'string');
+
+  // If workspace data is header-only, keep only sessions that actually have global bubbles.
+  const isHeaderOnly = sourceResult.composers.every((composer) => {
+    const keys = Object.keys(composer).filter((key) => key !== 'composerId');
+    return keys.length === 0;
+  });
+  if (isHeaderOnly) {
+    const withBubbles = sessionIds.filter((sessionId) => getComposerBubbleCountInGlobalStorage(sessionId) > 0);
+    if (withBubbles.length > 0) {
+      sessionIds = withBubbles;
+    }
+  }
 
   if (sessionIds.length === 0) {
     throw new NoSessionsFoundError(normalizedSource);
   }
 
   // Migrate all sessions
-  const results = await migrateSessions({
-    sessionIds,
-    destination: normalizedDest,
-    mode,
-    dryRun,
-    force,
-    dataPath,
-    debug,
-  });
+  const results: SessionMigrationResult[] = [];
+  for (const sessionId of sessionIds) {
+    try {
+      const result = await migrateSession(sessionId, {
+        destination: normalizedDest,
+        mode,
+        dryRun,
+        force,
+        dataPath,
+        debug,
+        sourceWorkspacePath: normalizedSource,
+      });
+      results.push(result);
+    } catch (error) {
+      results.push({
+        success: false,
+        sessionId,
+        sourceWorkspace: normalizedSource,
+        destinationWorkspace: normalizedDest,
+        mode,
+        error: error instanceof Error ? error.message : String(error),
+        dryRun,
+      });
+    }
+  }
 
   // Aggregate results
   const successCount = results.filter((r) => r.success).length;

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -74,7 +74,7 @@ export interface CursorChatBundle {
  * Handles both legacy and new Cursor formats
  */
 export function parseChatData(jsonString: string, bundle?: CursorChatBundle): ChatSession[] {
-  let data: RawChatData | ComposerData;
+  let data: RawChatData | ComposerData | ComposerHead[];
 
   try {
     data = JSON.parse(jsonString) as RawChatData | ComposerData;
@@ -82,9 +82,14 @@ export function parseChatData(jsonString: string, bundle?: CursorChatBundle): Ch
     return [];
   }
 
-  // Check if this is the new composer format
-  if ('allComposers' in data && data.allComposers) {
+  // New composer format with allComposers wrapper
+  if (isComposerData(data)) {
     return parseComposerFormat(data as ComposerData, bundle);
+  }
+
+  // Legacy composer format stored as a direct array
+  if (isComposerArray(data)) {
+    return parseComposerFormat({ allComposers: data }, bundle);
   }
 
   // Legacy format
@@ -100,6 +105,24 @@ export function parseChatData(jsonString: string, bundle?: CursorChatBundle): Ch
   }
 
   return sessions;
+}
+
+function isComposerData(data: RawChatData | ComposerData | ComposerHead[]): data is ComposerData {
+  return !!data && typeof data === 'object' && !Array.isArray(data) && 'allComposers' in data;
+}
+
+function isComposerArray(data: RawChatData | ComposerData | ComposerHead[]): data is ComposerHead[] {
+  if (!Array.isArray(data) || data.length === 0) {
+    return false;
+  }
+
+  return data.every(
+    (item) =>
+      !!item &&
+      typeof item === 'object' &&
+      !Array.isArray(item) &&
+      ('composerId' in item || 'name' in item || 'unifiedMode' in item)
+  );
 }
 
 /**

--- a/src/core/storage.ts
+++ b/src/core/storage.ts
@@ -104,6 +104,15 @@ interface BubbleRow {
   value: string;
 }
 
+interface GlobalComposerSummary {
+  id: string;
+  title: string | null;
+  createdAt: Date;
+  lastUpdatedAt: Date;
+  messageCount: number;
+  preview: string;
+}
+
 type BubbleMessage = Omit<Message, 'timestamp'> & { timestamp: Date | null };
 
 function getErrorMessage(error: unknown): string {
@@ -127,6 +136,64 @@ function closeDatabase(db: Database | null): void {
 
 function getBubbleRowId(rowKey: string): string | null {
   return rowKey.split(':').pop() ?? null;
+}
+
+function extractComposerIdsFromData(
+  dataText: string | undefined
+): Array<{ composerId: string; source: 'allComposers' | 'selectedComposerIds' }> {
+  if (!dataText) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(dataText) as unknown;
+    const ids = new Map<string, 'allComposers' | 'selectedComposerIds'>();
+
+    if (Array.isArray(parsed)) {
+      for (const entry of parsed) {
+        if (!entry || typeof entry !== 'object') continue;
+        const composerId = (entry as { composerId?: unknown }).composerId;
+        if (typeof composerId === 'string' && composerId.trim().length > 0) {
+          ids.set(composerId, 'allComposers');
+        }
+      }
+    } else if (parsed && typeof parsed === 'object') {
+      const allComposers = (parsed as { allComposers?: unknown }).allComposers;
+      if (Array.isArray(allComposers)) {
+        for (const entry of allComposers) {
+          if (!entry || typeof entry !== 'object') continue;
+          const composerId = (entry as { composerId?: unknown }).composerId;
+          if (typeof composerId === 'string' && composerId.trim().length > 0) {
+            ids.set(composerId, 'allComposers');
+          }
+        }
+      }
+
+      const selected = (parsed as { selectedComposerIds?: unknown }).selectedComposerIds;
+      if (Array.isArray(selected)) {
+        for (const composerId of selected) {
+          if (typeof composerId === 'string' && composerId.trim().length > 0 && !ids.has(composerId)) {
+            ids.set(composerId, 'selectedComposerIds');
+          }
+        }
+      }
+    }
+
+    return [...ids.entries()].map(([composerId, source]) => ({ composerId, source }));
+  } catch {
+    return [];
+  }
+}
+
+function countGlobalBubblesForComposerId(db: Database, composerId: string): number {
+  try {
+    const row = db.prepare('SELECT COUNT(*) as count FROM cursorDiskKV WHERE key LIKE ?').get(
+      `bubbleId:${composerId}:%`
+    ) as { count: number } | undefined;
+    return row?.count ?? 0;
+  } catch {
+    return 0;
+  }
 }
 
 function parseToolParams(
@@ -507,6 +574,9 @@ export async function findWorkspaces(
   }
 
   const workspaces: Workspace[] = [];
+  let globalDb: Database | null = null;
+  let globalDbChecked = false;
+  let globalDbAvailable = false;
 
   try {
     const entries = readdirSync(basePath, { withFileTypes: true });
@@ -519,8 +589,10 @@ export async function findWorkspaces(
 
       if (!existsSync(dbPath)) continue;
 
-      const workspacePath = readWorkspaceJson(workspaceDir);
-      if (!workspacePath) continue;
+      const workspacePath = readWorkspaceJson(workspaceDir) ?? `(workspace: ${entry.name})`;
+      if (workspacePath.startsWith('(workspace:')) {
+        debugLogStorage(`Using workspace ID fallback path for ${entry.name} (workspace.json missing/unknown)`);
+      }
 
       // Count sessions in this workspace
       let sessionCount = 0;
@@ -530,9 +602,52 @@ export async function findWorkspaces(
         if (result) {
           const parsed = parseChatData(result.data, result.bundle);
           sessionCount = parsed.length;
+          if (sessionCount === 0) {
+            const rawComposerData = result.bundle.composerData ?? result.data;
+            const composerRefs = extractComposerIdsFromData(rawComposerData);
+            const selectedIds = composerRefs
+              .filter((ref) => ref.source === 'selectedComposerIds')
+              .map((ref) => ref.composerId);
+            if (selectedIds.length > 0) {
+              if (!globalDbChecked) {
+                globalDbChecked = true;
+                const globalDbPath = join(getGlobalStoragePath(), 'state.vscdb');
+                if (existsSync(globalDbPath)) {
+                  try {
+                    globalDb = await openDatabase(globalDbPath);
+                    const tableCheck = globalDb
+                      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='cursorDiskKV'")
+                      .get();
+                    globalDbAvailable = Boolean(tableCheck);
+                  } catch {
+                    closeDatabase(globalDb);
+                    globalDb = null;
+                    globalDbAvailable = false;
+                  }
+                }
+              }
+
+              if (globalDb && globalDbAvailable) {
+                sessionCount = selectedIds.filter((composerId) => {
+                  return countGlobalBubblesForComposerId(globalDb as Database, composerId) > 0;
+                }).length;
+              } else {
+                sessionCount = selectedIds.length;
+              }
+
+              if (sessionCount > 0) {
+                debugLogStorage(
+                  `Workspace ${entry.name} counted via selectedComposerIds fallback: ${sessionCount}`
+                );
+              }
+            }
+          }
+        } else {
+          debugLogStorage(`No chat data keys found in workspace DB ${dbPath}`);
         }
         db.close();
-      } catch {
+      } catch (error) {
+        debugLogStorage(`Skipping unreadable workspace DB ${dbPath}: ${getErrorMessage(error)}`);
         // Skip workspaces with unreadable databases
         continue;
       }
@@ -548,6 +663,8 @@ export async function findWorkspaces(
     }
   } catch {
     return [];
+  } finally {
+    closeDatabase(globalDb);
   }
 
   return workspaces;
@@ -558,29 +675,44 @@ export async function findWorkspaces(
  * Returns both the main chat data and the bundle for new format
  */
 function getChatDataFromDb(db: Database): { data: string; bundle: CursorChatBundle } | null {
-  let mainData: string | null = null;
-  const bundle: CursorChatBundle = {};
-
-  // Try to get the main chat data
+  const candidates: Array<{ key: string; value: string }> = [];
   for (const key of CHAT_DATA_KEYS) {
     try {
       const row = db.prepare('SELECT value FROM ItemTable WHERE key = ?').get(key) as
         | { value: string }
         | undefined;
       if (row?.value) {
-        mainData = row.value;
-        if (key === 'composer.composerData') {
-          bundle.composerData = row.value;
-        }
-        break;
+        candidates.push({ key, value: row.value });
       }
     } catch {
       continue;
     }
   }
 
-  if (!mainData) {
+  if (candidates.length === 0) {
     return null;
+  }
+
+  let selected = candidates[0]!;
+  let bestSessionCount = -1;
+
+  for (const candidate of candidates) {
+    const candidateBundle: CursorChatBundle = {};
+    if (candidate.key === 'composer.composerData') {
+      candidateBundle.composerData = candidate.value;
+    }
+
+    const parsedCount = parseChatData(candidate.value, candidateBundle).length;
+    if (parsedCount > bestSessionCount) {
+      selected = candidate;
+      bestSessionCount = parsedCount;
+    }
+  }
+
+  const mainData = selected.value;
+  const bundle: CursorChatBundle = {};
+  if (selected.key === 'composer.composerData') {
+    bundle.composerData = selected.value;
   }
 
   // For new format, also get prompts and generations
@@ -607,6 +739,59 @@ function getChatDataFromDb(db: Database): { data: string; bundle: CursorChatBund
   }
 
   return { data: mainData, bundle };
+}
+
+function getGlobalComposerSummary(db: Database, composerId: string): GlobalComposerSummary | null {
+  try {
+    const composerRow = db.prepare('SELECT value FROM cursorDiskKV WHERE key = ?').get(
+      `composerData:${composerId}`
+    ) as { value: string } | undefined;
+    if (!composerRow?.value) {
+      return null;
+    }
+
+    const composerData = JSON.parse(composerRow.value) as {
+      name?: string;
+      title?: string;
+      createdAt?: string;
+      updatedAt?: string;
+    };
+
+    const bubbleCount = db
+      .prepare('SELECT COUNT(*) as count FROM cursorDiskKV WHERE key LIKE ?')
+      .get(`bubbleId:${composerId}:%`) as { count: number };
+    if (bubbleCount.count <= 0) {
+      return null;
+    }
+
+    const firstBubble = db
+      .prepare('SELECT value FROM cursorDiskKV WHERE key LIKE ? ORDER BY rowid ASC LIMIT 1')
+      .get(`bubbleId:${composerId}:%`) as { value: string } | undefined;
+
+    let preview = '';
+    if (firstBubble?.value) {
+      try {
+        const bubbleData = JSON.parse(firstBubble.value) as Record<string, unknown>;
+        preview = extractBubbleText(bubbleData).slice(0, 100);
+      } catch {
+        preview = '';
+      }
+    }
+
+    const createdAt = composerData.createdAt ? new Date(composerData.createdAt) : new Date();
+    const lastUpdatedAt = composerData.updatedAt ? new Date(composerData.updatedAt) : createdAt;
+
+    return {
+      id: composerId,
+      title: composerData.name ?? composerData.title ?? null,
+      createdAt,
+      lastUpdatedAt,
+      messageCount: bubbleCount.count,
+      preview,
+    };
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -646,6 +831,7 @@ export async function listSessions(
   const allSessions: ChatSessionSummary[] = [];
   // When listing all workspaces (no filter), dedupe by session id; keep first occurrence (workspace order is already deterministic)
   const seenIds = options.workspacePath ? null : new Set<string>();
+  const globalFallbackCandidates: Array<{ workspace: Workspace; composerIds: string[] }> = [];
 
   for (const workspace of filteredWorkspaces) {
     try {
@@ -659,6 +845,20 @@ export async function listSessions(
       if (!result) continue;
 
       const sessions = parseChatData(result.data, result.bundle);
+
+      if (sessions.length === 0) {
+        const rawComposerData = result.bundle.composerData ?? result.data;
+        const composerRefs = extractComposerIdsFromData(rawComposerData);
+        const selectedIds = composerRefs
+          .filter((ref) => ref.source === 'selectedComposerIds')
+          .map((ref) => ref.composerId);
+        if (selectedIds.length > 0) {
+          debugLogStorage(
+            `Workspace ${workspace.id} has selectedComposerIds fallback candidates: ${selectedIds.length}`
+          );
+          globalFallbackCandidates.push({ workspace, composerIds: selectedIds });
+        }
+      }
 
       for (const session of sessions) {
         if (seenIds?.has(session.id)) continue;
@@ -675,8 +875,59 @@ export async function listSessions(
           preview: session.messages[0]?.content.slice(0, 100) ?? '(Empty session)',
         });
       }
-    } catch {
+    } catch (error) {
+      debugLogStorage(
+        `Skipping workspace ${workspace.id} while listing sessions: ${getErrorMessage(error)}`
+      );
       continue;
+    }
+  }
+
+  if (!backupPath && globalFallbackCandidates.length > 0) {
+    const globalDbPath = join(getGlobalStoragePath(), 'state.vscdb');
+    if (existsSync(globalDbPath)) {
+      let globalDb: Database | null = null;
+      try {
+        globalDb = await openDatabase(globalDbPath);
+        const tableCheck = globalDb
+          .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='cursorDiskKV'")
+          .get();
+
+        if (tableCheck) {
+          const summaryCache = new Map<string, GlobalComposerSummary | null>();
+          for (const candidate of globalFallbackCandidates) {
+            for (const composerId of candidate.composerIds) {
+              if (seenIds?.has(composerId)) continue;
+
+              if (!summaryCache.has(composerId)) {
+                summaryCache.set(composerId, getGlobalComposerSummary(globalDb, composerId));
+              }
+
+              const summary = summaryCache.get(composerId);
+              if (!summary) {
+                continue;
+              }
+
+              seenIds?.add(summary.id);
+              allSessions.push({
+                id: summary.id,
+                index: 0,
+                title: summary.title,
+                createdAt: summary.createdAt,
+                lastUpdatedAt: summary.lastUpdatedAt,
+                messageCount: summary.messageCount,
+                workspaceId: candidate.workspace.id,
+                workspacePath: contractPath(candidate.workspace.path),
+                preview: summary.preview || '(Empty session)',
+              });
+            }
+          }
+        }
+      } catch (error) {
+        debugLogStorage(`Failed to load global fallback sessions: ${getErrorMessage(error)}`);
+      } finally {
+        closeDatabase(globalDb);
+      }
     }
   }
 
@@ -1979,20 +2230,8 @@ export async function findWorkspaceForSession(
 
       if (!result) continue;
 
-      // Parse the composerData - could be new format with allComposers or legacy format
-      const parsed = JSON.parse(result.data) as
-        | { allComposers?: Array<{ composerId?: string }> }
-        | Array<{ composerId?: string }>;
-
-      // Handle new format with allComposers array
-      let composers: Array<{ composerId?: string }>;
-      if ('allComposers' in parsed && Array.isArray(parsed.allComposers)) {
-        composers = parsed.allComposers;
-      } else if (Array.isArray(parsed)) {
-        composers = parsed;
-      } else {
-        continue;
-      }
+      const composerRefs = extractComposerIdsFromData(result.bundle.composerData ?? result.data);
+      const composers = composerRefs.map((ref) => ({ composerId: ref.composerId }));
 
       const found = composers.some((session) => session.composerId === sessionId);
 
@@ -2024,6 +2263,40 @@ export async function findWorkspaceByPath(
     if (pathsEqual(workspace.path, normalizedPath)) {
       return { workspace, dbPath: workspace.dbPath };
     }
+  }
+
+  // Fallback: include workspaces with zero sessions so migrations can target empty destinations.
+  const basePath = getCursorDataPath(customDataPath);
+  if (!existsSync(basePath)) {
+    return null;
+  }
+
+  try {
+    const entries = readdirSync(basePath, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+
+      const workspaceDir = join(basePath, entry.name);
+      const dbPath = join(workspaceDir, 'state.vscdb');
+      if (!existsSync(dbPath)) continue;
+
+      const workspacePathFromJson = readWorkspaceJson(workspaceDir);
+      if (!workspacePathFromJson) continue;
+
+      if (pathsEqual(workspacePathFromJson, normalizedPath)) {
+        return {
+          workspace: {
+            id: entry.name,
+            path: workspacePathFromJson,
+            dbPath,
+            sessionCount: 0,
+          },
+          dbPath,
+        };
+      }
+    }
+  } catch {
+    return null;
   }
 
   return null;
@@ -2061,9 +2334,37 @@ export function getComposerData(db: Database): ComposerDataResult | null {
     if (rawData && typeof rawData === 'object' && 'allComposers' in rawData) {
       const data = rawData as {
         allComposers: Array<{ composerId?: string; [key: string]: unknown }>;
+        selectedComposerIds?: unknown[];
       };
+      const selectedComposers = Array.isArray(data.selectedComposerIds)
+        ? data.selectedComposerIds
+            .filter((id): id is string => typeof id === 'string' && id.trim().length > 0)
+            .map((id) => ({ composerId: id }))
+        : [];
+
       return {
-        composers: data.allComposers ?? [],
+        composers:
+          Array.isArray(data.allComposers) && data.allComposers.length > 0
+            ? data.allComposers
+            : selectedComposers,
+        rawData,
+        isNewFormat: true,
+      };
+    }
+
+    // Newer workspace shape: selectedComposerIds only (no allComposers list)
+    if (
+      rawData &&
+      typeof rawData === 'object' &&
+      'selectedComposerIds' in rawData &&
+      Array.isArray((rawData as { selectedComposerIds?: unknown }).selectedComposerIds)
+    ) {
+      const selectedComposers = (rawData as { selectedComposerIds: unknown[] }).selectedComposerIds
+        .filter((id): id is string => typeof id === 'string' && id.trim().length > 0)
+        .map((id) => ({ composerId: id }));
+
+      return {
+        composers: selectedComposers,
         rawData,
         isNewFormat: true,
       };
@@ -2099,7 +2400,24 @@ export function updateComposerData(
   if (isNewFormat) {
     // Preserve the original structure, just update allComposers
     if (originalRawData && typeof originalRawData === 'object') {
-      dataToWrite = { ...(originalRawData as object), allComposers: composers };
+      const original = originalRawData as Record<string, unknown>;
+      const selectedOnly =
+        Array.isArray(original['selectedComposerIds']) && !Array.isArray(original['allComposers']);
+      const nextData: Record<string, unknown> = { ...original, allComposers: composers };
+
+      if (selectedOnly) {
+        const selectedComposerIds = composers
+          .map((composer) => composer.composerId)
+          .filter((id): id is string => typeof id === 'string' && id.trim().length > 0);
+        nextData['selectedComposerIds'] = selectedComposerIds;
+
+        if (Array.isArray(original['lastFocusedComposerIds'])) {
+          nextData['lastFocusedComposerIds'] =
+            selectedComposerIds.length > 0 ? [selectedComposerIds[0]!] : [];
+        }
+      }
+
+      dataToWrite = nextData;
     } else {
       dataToWrite = { allComposers: composers };
     }

--- a/src/core/storage.ts
+++ b/src/core/storage.ts
@@ -218,6 +218,38 @@ function composerBelongsToWorkspace(composerData: Record<string, unknown>, works
   return workspacePathMatches(composerData['workspaceUri'], workspace.path);
 }
 
+/** Whether a global composer record carries any explicit workspace attribution. */
+function composerHasWorkspaceStamp(composerData: Record<string, unknown>): boolean {
+  if (isRecord(composerData['workspaceIdentifier'])) {
+    return true;
+  }
+  const workspaceUri = composerData['workspaceUri'];
+  return typeof workspaceUri === 'string' && workspaceUri.length > 0;
+}
+
+/**
+ * Best-effort workspace path for a global composer that is not attributed to any
+ * discovered workspace, derived from whatever workspace metadata the record does
+ * carry. Returns null when the record has no usable workspace hint.
+ */
+function workspacePathFromComposer(composerData: Record<string, unknown>): string | null {
+  const workspaceIdentifier = composerData['workspaceIdentifier'];
+  if (isRecord(workspaceIdentifier) && isRecord(workspaceIdentifier['uri'])) {
+    const uri = workspaceIdentifier['uri'] as Record<string, unknown>;
+    for (const field of ['fsPath', 'path', 'external'] as const) {
+      const value = uri[field];
+      if (typeof value === 'string' && value.length > 0) {
+        return uriToPath(value);
+      }
+    }
+  }
+  const workspaceUri = composerData['workspaceUri'];
+  if (typeof workspaceUri === 'string' && workspaceUri.length > 0) {
+    return uriToPath(workspaceUri);
+  }
+  return null;
+}
+
 function extractComposerIdsFromData(
   dataText: string | undefined
 ): Array<{ composerId: string; source: ChatDataSource }> {
@@ -265,14 +297,36 @@ function extractComposerIdsFromData(
   }
 }
 
-function countGlobalBubblesForComposerId(db: Database, composerId: string): number {
+const COMPOSER_GUID_RE =
+  /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/g;
+
+/**
+ * Modern Cursor links a workspace to its agent/composer sessions through
+ * per-workspace UI-state pointer keys (e.g. `workbench.panel.composerChatViewPane.<guid>`)
+ * rather than stamping the workspace into the global composer record. Extract the
+ * composer GUIDs referenced by those pointers so they can be resolved from global
+ * storage. GUIDs that are not real composers simply resolve to nothing downstream.
+ */
+function getWorkspaceComposerPointerIds(db: Database): string[] {
   try {
-    const row = db.prepare('SELECT COUNT(*) as count FROM cursorDiskKV WHERE key LIKE ?').get(
-      `bubbleId:${composerId}:%`
-    ) as { count: number } | undefined;
-    return row?.count ?? 0;
+    const rows = db
+      .prepare("SELECT key, value FROM ItemTable WHERE key LIKE '%composerChatViewPane%'")
+      .all() as { key: string; value: string }[];
+    const ids = new Set<string>();
+    for (const row of rows) {
+      for (const source of [row.key, row.value]) {
+        if (typeof source !== 'string') continue;
+        const matches = source.match(COMPOSER_GUID_RE);
+        if (matches) {
+          for (const match of matches) {
+            ids.add(match.toLowerCase());
+          }
+        }
+      }
+    }
+    return [...ids];
   } catch {
-    return 0;
+    return [];
   }
 }
 
@@ -658,6 +712,7 @@ export async function findWorkspaces(
   let globalDbChecked = false;
   let globalDbAvailable = false;
   let globalComposerRecords: GlobalComposerRecord[] = [];
+  let globalBubbleCounts = new Map<string, number>();
   // Run-level set so a global composer is counted for at most one workspace,
   // keeping `list --workspaces` counts consistent with the deduped `list` output.
   const attributedComposerIds = new Set<string>();
@@ -682,6 +737,7 @@ export async function findWorkspaces(
       let sessionCount = 0;
       const seenComposerIds = new Set<string>();
       const selectedIds: string[] = [];
+      const pointerIds: string[] = [];
       try {
         const db = await openDatabase(dbPath);
         const result = getChatDataFromDb(db);
@@ -703,6 +759,8 @@ export async function findWorkspaces(
         } else {
           debugLogStorage(`No chat data keys found in workspace DB ${dbPath}`);
         }
+        // Pointer keys live in ItemTable independently of composer.composerData.
+        pointerIds.push(...getWorkspaceComposerPointerIds(db));
         db.close();
       } catch (error) {
         debugLogStorage(`Skipping unreadable workspace DB ${dbPath}: ${getErrorMessage(error)}`);
@@ -722,6 +780,7 @@ export async function findWorkspaces(
             globalDbAvailable = Boolean(tableCheck);
             if (globalDbAvailable) {
               globalComposerRecords = loadGlobalComposerRecords(globalDb);
+              globalBubbleCounts = loadGlobalBubbleCounts(globalDb);
             }
           } catch {
             closeDatabase(globalDb);
@@ -732,9 +791,11 @@ export async function findWorkspaces(
       }
 
       if (globalDb && globalDbAvailable) {
-        for (const composerId of selectedIds) {
+        // Selected + pointer IDs are only counted when they resolve to a real
+        // global composer with bubbles, so non-composer GUIDs never inflate counts.
+        for (const composerId of [...selectedIds, ...pointerIds]) {
           if (seenComposerIds.has(composerId) || attributedComposerIds.has(composerId)) continue;
-          if (countGlobalBubblesForComposerId(globalDb, composerId) > 0) {
+          if ((globalBubbleCounts.get(composerId) ?? 0) > 0) {
             seenComposerIds.add(composerId);
             attributedComposerIds.add(composerId);
             sessionCount++;
@@ -750,7 +811,8 @@ export async function findWorkspaces(
         for (const summary of getGlobalComposerSummariesForWorkspace(
           globalDb,
           workspaceForGlobalMatch,
-          globalComposerRecords
+          globalComposerRecords,
+          globalBubbleCounts
         )) {
           if (seenComposerIds.has(summary.id) || attributedComposerIds.has(summary.id)) continue;
           seenComposerIds.add(summary.id);
@@ -758,6 +820,8 @@ export async function findWorkspaces(
           sessionCount++;
         }
       } else {
+        // No global storage: pointer GUIDs cannot be confirmed as composers, so
+        // only count real selectedComposerIds (avoid phantom session counts).
         for (const composerId of selectedIds) {
           if (seenComposerIds.has(composerId) || attributedComposerIds.has(composerId)) continue;
           seenComposerIds.add(composerId);
@@ -856,29 +920,59 @@ function getChatDataFromDb(db: Database): ChatDataResult | null {
   return { data: mainData, bundle };
 }
 
+/**
+ * Count bubbles per composer in a single pass over global storage, instead of one
+ * `COUNT(*) ... LIKE 'bubbleId:<id>:%'` full scan per composer. Reused across the
+ * recovery passes so listing stays roughly one bubble-table scan rather than O(C).
+ */
+function loadGlobalBubbleCounts(db: Database): Map<string, number> {
+  const counts = new Map<string, number>();
+  try {
+    const rows = db
+      .prepare("SELECT key FROM cursorDiskKV WHERE key LIKE 'bubbleId:%'")
+      .all() as { key: string }[];
+    for (const row of rows) {
+      // key form: bubbleId:<composerId>:<bubbleId>
+      const composerId = row.key.split(':')[1];
+      if (composerId) {
+        counts.set(composerId, (counts.get(composerId) ?? 0) + 1);
+      }
+    }
+  } catch {
+    // Fall back to per-composer counting when the scan fails.
+  }
+  return counts;
+}
+
 function buildGlobalComposerSummary(
   db: Database,
   composerId: string,
-  composerData: Record<string, unknown>
+  composerData: Record<string, unknown>,
+  options?: { bubbleCount?: number; includePreview?: boolean }
 ): GlobalComposerSummary | null {
-  const bubbleCount = db
-    .prepare('SELECT COUNT(*) as count FROM cursorDiskKV WHERE key LIKE ?')
-    .get(`bubbleId:${composerId}:%`) as { count: number };
-  if (bubbleCount.count <= 0) {
+  const messageCount =
+    options?.bubbleCount ??
+    ((
+      db
+        .prepare('SELECT COUNT(*) as count FROM cursorDiskKV WHERE key LIKE ?')
+        .get(`bubbleId:${composerId}:%`) as { count: number }
+    ).count);
+  if (messageCount <= 0) {
     return null;
   }
 
-  const firstBubble = db
-    .prepare('SELECT value FROM cursorDiskKV WHERE key LIKE ? ORDER BY rowid ASC LIMIT 1')
-    .get(`bubbleId:${composerId}:%`) as { value: string } | undefined;
-
   let preview = '';
-  if (firstBubble?.value) {
-    try {
-      const bubbleData = JSON.parse(firstBubble.value) as Record<string, unknown>;
-      preview = extractBubbleText(bubbleData).slice(0, 100);
-    } catch {
-      preview = '';
+  if (options?.includePreview !== false) {
+    const firstBubble = db
+      .prepare('SELECT value FROM cursorDiskKV WHERE key LIKE ? ORDER BY rowid ASC LIMIT 1')
+      .get(`bubbleId:${composerId}:%`) as { value: string } | undefined;
+    if (firstBubble?.value) {
+      try {
+        const bubbleData = JSON.parse(firstBubble.value) as Record<string, unknown>;
+        preview = extractBubbleText(bubbleData).slice(0, 100);
+      } catch {
+        preview = '';
+      }
     }
   }
 
@@ -898,12 +992,16 @@ function buildGlobalComposerSummary(
           : null,
     createdAt,
     lastUpdatedAt,
-    messageCount: bubbleCount.count,
+    messageCount,
     preview,
   };
 }
 
-function getGlobalComposerSummary(db: Database, composerId: string): GlobalComposerSummary | null {
+function getGlobalComposerSummary(
+  db: Database,
+  composerId: string,
+  bubbleCounts?: Map<string, number>
+): GlobalComposerSummary | null {
   try {
     const composerRow = db.prepare('SELECT value FROM cursorDiskKV WHERE key = ?').get(
       `composerData:${composerId}`
@@ -917,7 +1015,9 @@ function getGlobalComposerSummary(db: Database, composerId: string): GlobalCompo
       return null;
     }
 
-    return buildGlobalComposerSummary(db, composerId, composerData);
+    return buildGlobalComposerSummary(db, composerId, composerData, {
+      bubbleCount: bubbleCounts?.get(composerId),
+    });
   } catch {
     return null;
   }
@@ -955,7 +1055,8 @@ function loadGlobalComposerRecords(db: Database): GlobalComposerRecord[] {
 function getGlobalComposerSummariesForWorkspace(
   db: Database,
   workspace: Workspace,
-  records: GlobalComposerRecord[]
+  records: GlobalComposerRecord[],
+  bubbleCounts?: Map<string, number>
 ): GlobalComposerSummary[] {
   const summaries: GlobalComposerSummary[] = [];
 
@@ -964,7 +1065,9 @@ function getGlobalComposerSummariesForWorkspace(
       continue;
     }
 
-    const summary = buildGlobalComposerSummary(db, record.id, record.data);
+    const summary = buildGlobalComposerSummary(db, record.id, record.data, {
+      bubbleCount: bubbleCounts?.get(record.id),
+    });
     if (summary) {
       summaries.push(summary);
     }
@@ -995,13 +1098,38 @@ export async function getWorkspaceLinkedComposerIds(workspace: Workspace): Promi
       return [];
     }
 
-    const ids: string[] = [];
-    for (const record of loadGlobalComposerRecords(db)) {
+    const ids = new Set<string>();
+    const records = loadGlobalComposerRecords(db);
+    const recordById = new Map(records.map((record) => [record.id, record.data]));
+    for (const record of records) {
       if (composerBelongsToWorkspace(record.data, workspace)) {
-        ids.push(record.id);
+        ids.add(record.id);
       }
     }
-    return ids;
+
+    // Also include composers referenced by this workspace's pointer keys (the
+    // modern linkage). Because migration is destructive, only include a pointer ID
+    // when its record is unstamped or already belongs to this workspace — never one
+    // explicitly stamped for a different workspace (which the user merely viewed).
+    if (existsSync(workspace.dbPath)) {
+      let wsDb: Database | null = null;
+      try {
+        wsDb = await openDatabase(workspace.dbPath);
+        for (const pointerId of getWorkspaceComposerPointerIds(wsDb)) {
+          const data = recordById.get(pointerId);
+          if (!data) continue;
+          if (!composerHasWorkspaceStamp(data) || composerBelongsToWorkspace(data, workspace)) {
+            ids.add(pointerId);
+          }
+        }
+      } catch {
+        // Ignore unreadable workspace DB; global-linked IDs are still returned.
+      } finally {
+        closeDatabase(wsDb);
+      }
+    }
+
+    return [...ids];
   } catch (error) {
     debugLogStorage(`Failed to load workspace-linked composer IDs: ${getErrorMessage(error)}`);
     return [];
@@ -1056,6 +1184,9 @@ export async function listSessions(
         ? await openBackupDatabase(backupPath, workspace.dbPath)
         : await openDatabase(workspace.dbPath);
       const result = getChatDataFromDb(db);
+      // Pointer keys (e.g. composerChatViewPane.<guid>) live in ItemTable and link
+      // this workspace to its global composers even when no workspace stamp exists.
+      const pointerIds = backupPath ? [] : getWorkspaceComposerPointerIds(db);
       db.close();
 
       const sessions = result ? parseChatData(result.data, result.bundle) : [];
@@ -1070,11 +1201,12 @@ export async function listSessions(
             .filter((ref) => ref.source === 'selectedComposerIds')
             .map((ref) => ref.composerId)
         );
-        if (selectedIds.length > 0) {
-          debugLogStorage(
-            `Workspace ${workspace.id} has selectedComposerIds fallback candidates: ${selectedIds.length}`
-          );
-        }
+      }
+      selectedIds.push(...pointerIds);
+      if (selectedIds.length > 0) {
+        debugLogStorage(
+          `Workspace ${workspace.id} has ${selectedIds.length} global recovery candidate(s)`
+        );
       }
 
       for (const session of sessions) {
@@ -1110,7 +1242,7 @@ export async function listSessions(
     }
   }
 
-  if (!backupPath && globalFallbackCandidates.length > 0) {
+  if (!backupPath && (globalFallbackCandidates.length > 0 || !options.workspacePath)) {
     const globalDbPath = join(getGlobalStoragePath(), 'state.vscdb');
     if (existsSync(globalDbPath)) {
       let globalDb: Database | null = null;
@@ -1122,6 +1254,8 @@ export async function listSessions(
 
         if (tableCheck) {
           const globalComposerRecords = loadGlobalComposerRecords(globalDb);
+          // One pass over the bubble table instead of two LIKE scans per composer.
+          const globalBubbleCounts = loadGlobalBubbleCounts(globalDb);
           const summaryCache = new Map<string, GlobalComposerSummary | null>();
           // Dedup recovered sessions across candidates even under `--workspace`
           // (where the shared `seenIds` is intentionally null), so a single global
@@ -1134,7 +1268,10 @@ export async function listSessions(
               if (recoveredIds.has(composerId)) continue;
 
               if (!summaryCache.has(composerId)) {
-                summaryCache.set(composerId, getGlobalComposerSummary(globalDb, composerId));
+                summaryCache.set(
+                  composerId,
+                  getGlobalComposerSummary(globalDb, composerId, globalBubbleCounts)
+                );
               }
 
               const summary = summaryCache.get(composerId);
@@ -1162,7 +1299,8 @@ export async function listSessions(
               for (const summary of getGlobalComposerSummariesForWorkspace(
                 globalDb,
                 candidate.workspace,
-                globalComposerRecords
+                globalComposerRecords,
+                globalBubbleCounts
               )) {
                 if (candidate.existingIds.has(summary.id)) continue;
                 if (seenIds?.has(summary.id)) continue;
@@ -1183,6 +1321,40 @@ export async function listSessions(
                   preview: summary.preview || '(Empty session)',
                 });
               }
+            }
+          }
+
+          // Catch-all: surface global composers that could not be attributed to any
+          // workspace (modern Cursor frequently stores no workspace stamp on the
+          // global record). Only on the unfiltered listing, where `seenIds` tracks
+          // everything already shown.
+          if (seenIds && !options.workspacePath) {
+            for (const record of globalComposerRecords) {
+              if (seenIds.has(record.id) || recoveredIds.has(record.id)) continue;
+
+              // Use the precomputed bubble counts and skip the per-composer
+              // first-bubble preview query so the catch-all stays ~one scan total
+              // even when hundreds of composers are unattributed.
+              const summary = buildGlobalComposerSummary(globalDb, record.id, record.data, {
+                bubbleCount: globalBubbleCounts.get(record.id) ?? 0,
+                includePreview: false,
+              });
+              if (!summary) continue;
+
+              seenIds.add(summary.id);
+              recoveredIds.add(summary.id);
+              const derivedPath = workspacePathFromComposer(record.data);
+              allSessions.push({
+                id: summary.id,
+                index: 0,
+                title: summary.title,
+                createdAt: summary.createdAt,
+                lastUpdatedAt: summary.lastUpdatedAt,
+                messageCount: summary.messageCount,
+                workspaceId: 'global',
+                workspacePath: derivedPath ? contractPath(derivedPath) : '(global)',
+                preview: summary.preview || '(Empty session)',
+              });
             }
           }
         }

--- a/src/core/storage.ts
+++ b/src/core/storage.ts
@@ -115,6 +115,20 @@ interface GlobalComposerSummary {
 
 type BubbleMessage = Omit<Message, 'timestamp'> & { timestamp: Date | null };
 
+type ChatDataSource = 'allComposers' | 'selectedComposerIds';
+
+interface ChatDataResult {
+  data: string;
+  bundle: CursorChatBundle;
+}
+
+interface WorkspaceGlobalCandidate {
+  workspace: Workspace;
+  composerIds: string[];
+  existingIds: Set<string>;
+  includeWorkspaceLinked: boolean;
+}
+
 function getErrorMessage(error: unknown): string {
   if (error instanceof Error && error.message) {
     return error.message;
@@ -138,16 +152,63 @@ function getBubbleRowId(rowKey: string): string | null {
   return rowKey.split(':').pop() ?? null;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function parseDateValue(value: unknown): Date | null {
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    return null;
+  }
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function uriToPath(uri: string): string {
+  try {
+    return decodeURIComponent(uri.replace(/^file:\/\//, ''));
+  } catch {
+    return uri.replace(/^file:\/\//, '');
+  }
+}
+
+function workspacePathMatches(candidatePath: unknown, workspacePath: string): boolean {
+  return typeof candidatePath === 'string' && pathsEqual(uriToPath(candidatePath), workspacePath);
+}
+
+function composerBelongsToWorkspace(composerData: Record<string, unknown>, workspace: Workspace): boolean {
+  const workspaceIdentifier = composerData['workspaceIdentifier'];
+  if (isRecord(workspaceIdentifier)) {
+    if (workspaceIdentifier['id'] === workspace.id) {
+      return true;
+    }
+
+    const uri = workspaceIdentifier['uri'];
+    if (isRecord(uri)) {
+      if (
+        workspacePathMatches(uri['fsPath'], workspace.path) ||
+        workspacePathMatches(uri['path'], workspace.path) ||
+        workspacePathMatches(uri['external'], workspace.path)
+      ) {
+        return true;
+      }
+    }
+  }
+
+  return workspacePathMatches(composerData['workspaceUri'], workspace.path);
+}
+
 function extractComposerIdsFromData(
   dataText: string | undefined
-): Array<{ composerId: string; source: 'allComposers' | 'selectedComposerIds' }> {
+): Array<{ composerId: string; source: ChatDataSource }> {
   if (!dataText) {
     return [];
   }
 
   try {
     const parsed = JSON.parse(dataText) as unknown;
-    const ids = new Map<string, 'allComposers' | 'selectedComposerIds'>();
+    const ids = new Map<string, ChatDataSource>();
 
     if (Array.isArray(parsed)) {
       for (const entry of parsed) {
@@ -596,52 +657,25 @@ export async function findWorkspaces(
 
       // Count sessions in this workspace
       let sessionCount = 0;
+      const seenComposerIds = new Set<string>();
+      const selectedIds: string[] = [];
       try {
         const db = await openDatabase(dbPath);
         const result = getChatDataFromDb(db);
         if (result) {
           const parsed = parseChatData(result.data, result.bundle);
           sessionCount = parsed.length;
-          if (sessionCount === 0) {
-            const rawComposerData = result.bundle.composerData ?? result.data;
-            const composerRefs = extractComposerIdsFromData(rawComposerData);
-            const selectedIds = composerRefs
-              .filter((ref) => ref.source === 'selectedComposerIds')
-              .map((ref) => ref.composerId);
-            if (selectedIds.length > 0) {
-              if (!globalDbChecked) {
-                globalDbChecked = true;
-                const globalDbPath = join(getGlobalStoragePath(), 'state.vscdb');
-                if (existsSync(globalDbPath)) {
-                  try {
-                    globalDb = await openDatabase(globalDbPath);
-                    const tableCheck = globalDb
-                      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='cursorDiskKV'")
-                      .get();
-                    globalDbAvailable = Boolean(tableCheck);
-                  } catch {
-                    closeDatabase(globalDb);
-                    globalDb = null;
-                    globalDbAvailable = false;
-                  }
-                }
-              }
-
-              if (globalDb && globalDbAvailable) {
-                sessionCount = selectedIds.filter((composerId) => {
-                  return countGlobalBubblesForComposerId(globalDb as Database, composerId) > 0;
-                }).length;
-              } else {
-                sessionCount = selectedIds.length;
-              }
-
-              if (sessionCount > 0) {
-                debugLogStorage(
-                  `Workspace ${entry.name} counted via selectedComposerIds fallback: ${sessionCount}`
-                );
-              }
-            }
+          for (const session of parsed) {
+            seenComposerIds.add(session.id);
           }
+
+          const rawComposerData = result.bundle.composerData;
+          const composerRefs = extractComposerIdsFromData(rawComposerData);
+          selectedIds.push(
+            ...composerRefs
+              .filter((ref) => ref.source === 'selectedComposerIds')
+              .map((ref) => ref.composerId)
+          );
         } else {
           debugLogStorage(`No chat data keys found in workspace DB ${dbPath}`);
         }
@@ -650,6 +684,55 @@ export async function findWorkspaces(
         debugLogStorage(`Skipping unreadable workspace DB ${dbPath}: ${getErrorMessage(error)}`);
         // Skip workspaces with unreadable databases
         continue;
+      }
+
+      if (!globalDbChecked) {
+        globalDbChecked = true;
+        const globalDbPath = join(getGlobalStoragePath(), 'state.vscdb');
+        if (existsSync(globalDbPath)) {
+          try {
+            globalDb = await openDatabase(globalDbPath);
+            const tableCheck = globalDb
+              .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='cursorDiskKV'")
+              .get();
+            globalDbAvailable = Boolean(tableCheck);
+          } catch {
+            closeDatabase(globalDb);
+            globalDb = null;
+            globalDbAvailable = false;
+          }
+        }
+      }
+
+      if (globalDb && globalDbAvailable) {
+        for (const composerId of selectedIds) {
+          if (seenComposerIds.has(composerId)) continue;
+          if (countGlobalBubblesForComposerId(globalDb, composerId) > 0) {
+            seenComposerIds.add(composerId);
+            sessionCount++;
+          }
+        }
+
+        const workspaceForGlobalMatch: Workspace = {
+          id: entry.name,
+          path: workspacePath,
+          dbPath,
+          sessionCount,
+        };
+        for (const summary of getGlobalComposerSummariesForWorkspace(
+          globalDb,
+          workspaceForGlobalMatch
+        )) {
+          if (seenComposerIds.has(summary.id)) continue;
+          seenComposerIds.add(summary.id);
+          sessionCount++;
+        }
+      } else {
+        for (const composerId of selectedIds) {
+          if (seenComposerIds.has(composerId)) continue;
+          seenComposerIds.add(composerId);
+          sessionCount++;
+        }
       }
 
       if (sessionCount > 0) {
@@ -674,7 +757,7 @@ export async function findWorkspaces(
  * Get chat data JSON from database
  * Returns both the main chat data and the bundle for new format
  */
-function getChatDataFromDb(db: Database): { data: string; bundle: CursorChatBundle } | null {
+function getChatDataFromDb(db: Database): ChatDataResult | null {
   const candidates: Array<{ key: string; value: string }> = [];
   for (const key of CHAT_DATA_KEYS) {
     try {
@@ -711,8 +794,9 @@ function getChatDataFromDb(db: Database): { data: string; bundle: CursorChatBund
 
   const mainData = selected.value;
   const bundle: CursorChatBundle = {};
-  if (selected.key === 'composer.composerData') {
-    bundle.composerData = selected.value;
+  const composerCandidate = candidates.find((candidate) => candidate.key === 'composer.composerData');
+  if (composerCandidate) {
+    bundle.composerData = composerCandidate.value;
   }
 
   // For new format, also get prompts and generations
@@ -741,6 +825,53 @@ function getChatDataFromDb(db: Database): { data: string; bundle: CursorChatBund
   return { data: mainData, bundle };
 }
 
+function buildGlobalComposerSummary(
+  db: Database,
+  composerId: string,
+  composerData: Record<string, unknown>
+): GlobalComposerSummary | null {
+  const bubbleCount = db
+    .prepare('SELECT COUNT(*) as count FROM cursorDiskKV WHERE key LIKE ?')
+    .get(`bubbleId:${composerId}:%`) as { count: number };
+  if (bubbleCount.count <= 0) {
+    return null;
+  }
+
+  const firstBubble = db
+    .prepare('SELECT value FROM cursorDiskKV WHERE key LIKE ? ORDER BY rowid ASC LIMIT 1')
+    .get(`bubbleId:${composerId}:%`) as { value: string } | undefined;
+
+  let preview = '';
+  if (firstBubble?.value) {
+    try {
+      const bubbleData = JSON.parse(firstBubble.value) as Record<string, unknown>;
+      preview = extractBubbleText(bubbleData).slice(0, 100);
+    } catch {
+      preview = '';
+    }
+  }
+
+  const createdAt = parseDateValue(composerData['createdAt']) ?? new Date();
+  const lastUpdatedAt =
+    parseDateValue(composerData['lastUpdatedAt']) ??
+    parseDateValue(composerData['updatedAt']) ??
+    createdAt;
+
+  return {
+    id: composerId,
+    title:
+      typeof composerData['name'] === 'string'
+        ? composerData['name']
+        : typeof composerData['title'] === 'string'
+          ? composerData['title']
+          : null,
+    createdAt,
+    lastUpdatedAt,
+    messageCount: bubbleCount.count,
+    preview,
+  };
+}
+
 function getGlobalComposerSummary(db: Database, composerId: string): GlobalComposerSummary | null {
   try {
     const composerRow = db.prepare('SELECT value FROM cursorDiskKV WHERE key = ?').get(
@@ -750,47 +881,47 @@ function getGlobalComposerSummary(db: Database, composerId: string): GlobalCompo
       return null;
     }
 
-    const composerData = JSON.parse(composerRow.value) as {
-      name?: string;
-      title?: string;
-      createdAt?: string;
-      updatedAt?: string;
-    };
-
-    const bubbleCount = db
-      .prepare('SELECT COUNT(*) as count FROM cursorDiskKV WHERE key LIKE ?')
-      .get(`bubbleId:${composerId}:%`) as { count: number };
-    if (bubbleCount.count <= 0) {
+    const composerData = JSON.parse(composerRow.value) as unknown;
+    if (!isRecord(composerData)) {
       return null;
     }
 
-    const firstBubble = db
-      .prepare('SELECT value FROM cursorDiskKV WHERE key LIKE ? ORDER BY rowid ASC LIMIT 1')
-      .get(`bubbleId:${composerId}:%`) as { value: string } | undefined;
+    return buildGlobalComposerSummary(db, composerId, composerData);
+  } catch {
+    return null;
+  }
+}
 
-    let preview = '';
-    if (firstBubble?.value) {
+function getGlobalComposerSummariesForWorkspace(
+  db: Database,
+  workspace: Workspace
+): GlobalComposerSummary[] {
+  try {
+    const rows = db
+      .prepare("SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%'")
+      .all() as { key: string; value: string }[];
+    const summaries: GlobalComposerSummary[] = [];
+
+    for (const row of rows) {
+      const composerId = row.key.replace('composerData:', '');
       try {
-        const bubbleData = JSON.parse(firstBubble.value) as Record<string, unknown>;
-        preview = extractBubbleText(bubbleData).slice(0, 100);
+        const composerData = JSON.parse(row.value) as unknown;
+        if (!isRecord(composerData) || !composerBelongsToWorkspace(composerData, workspace)) {
+          continue;
+        }
+
+        const summary = buildGlobalComposerSummary(db, composerId, composerData);
+        if (summary) {
+          summaries.push(summary);
+        }
       } catch {
-        preview = '';
+        continue;
       }
     }
 
-    const createdAt = composerData.createdAt ? new Date(composerData.createdAt) : new Date();
-    const lastUpdatedAt = composerData.updatedAt ? new Date(composerData.updatedAt) : createdAt;
-
-    return {
-      id: composerId,
-      title: composerData.name ?? composerData.title ?? null,
-      createdAt,
-      lastUpdatedAt,
-      messageCount: bubbleCount.count,
-      preview,
-    };
+    return summaries;
   } catch {
-    return null;
+    return [];
   }
 }
 
@@ -831,7 +962,7 @@ export async function listSessions(
   const allSessions: ChatSessionSummary[] = [];
   // When listing all workspaces (no filter), dedupe by session id; keep first occurrence (workspace order is already deterministic)
   const seenIds = options.workspacePath ? null : new Set<string>();
-  const globalFallbackCandidates: Array<{ workspace: Workspace; composerIds: string[] }> = [];
+  const globalFallbackCandidates: WorkspaceGlobalCandidate[] = [];
 
   for (const workspace of filteredWorkspaces) {
     try {
@@ -842,25 +973,27 @@ export async function listSessions(
       const result = getChatDataFromDb(db);
       db.close();
 
-      if (!result) continue;
+      const sessions = result ? parseChatData(result.data, result.bundle) : [];
+      const workspaceSeenIds = new Set<string>();
+      const selectedIds: string[] = [];
 
-      const sessions = parseChatData(result.data, result.bundle);
-
-      if (sessions.length === 0) {
-        const rawComposerData = result.bundle.composerData ?? result.data;
+      if (result) {
+        const rawComposerData = result.bundle.composerData;
         const composerRefs = extractComposerIdsFromData(rawComposerData);
-        const selectedIds = composerRefs
-          .filter((ref) => ref.source === 'selectedComposerIds')
-          .map((ref) => ref.composerId);
+        selectedIds.push(
+          ...composerRefs
+            .filter((ref) => ref.source === 'selectedComposerIds')
+            .map((ref) => ref.composerId)
+        );
         if (selectedIds.length > 0) {
           debugLogStorage(
             `Workspace ${workspace.id} has selectedComposerIds fallback candidates: ${selectedIds.length}`
           );
-          globalFallbackCandidates.push({ workspace, composerIds: selectedIds });
         }
       }
 
       for (const session of sessions) {
+        workspaceSeenIds.add(session.id);
         if (seenIds?.has(session.id)) continue;
         seenIds?.add(session.id);
         allSessions.push({
@@ -873,6 +1006,15 @@ export async function listSessions(
           workspaceId: workspace.id,
           workspacePath: contractPath(workspace.path),
           preview: session.messages[0]?.content.slice(0, 100) ?? '(Empty session)',
+        });
+      }
+
+      if (!backupPath) {
+        globalFallbackCandidates.push({
+          workspace,
+          composerIds: selectedIds,
+          existingIds: workspaceSeenIds,
+          includeWorkspaceLinked: true,
         });
       }
     } catch (error) {
@@ -897,6 +1039,7 @@ export async function listSessions(
           const summaryCache = new Map<string, GlobalComposerSummary | null>();
           for (const candidate of globalFallbackCandidates) {
             for (const composerId of candidate.composerIds) {
+              if (candidate.existingIds.has(composerId)) continue;
               if (seenIds?.has(composerId)) continue;
 
               if (!summaryCache.has(composerId)) {
@@ -908,6 +1051,7 @@ export async function listSessions(
                 continue;
               }
 
+              candidate.existingIds.add(summary.id);
               seenIds?.add(summary.id);
               allSessions.push({
                 id: summary.id,
@@ -920,6 +1064,30 @@ export async function listSessions(
                 workspacePath: contractPath(candidate.workspace.path),
                 preview: summary.preview || '(Empty session)',
               });
+            }
+
+            if (candidate.includeWorkspaceLinked) {
+              for (const summary of getGlobalComposerSummariesForWorkspace(
+                globalDb,
+                candidate.workspace
+              )) {
+                if (candidate.existingIds.has(summary.id)) continue;
+                if (seenIds?.has(summary.id)) continue;
+
+                candidate.existingIds.add(summary.id);
+                seenIds?.add(summary.id);
+                allSessions.push({
+                  id: summary.id,
+                  index: 0,
+                  title: summary.title,
+                  createdAt: summary.createdAt,
+                  lastUpdatedAt: summary.lastUpdatedAt,
+                  messageCount: summary.messageCount,
+                  workspaceId: candidate.workspace.id,
+                  workspacePath: contractPath(candidate.workspace.path),
+                  preview: summary.preview || '(Empty session)',
+                });
+              }
             }
           }
         }
@@ -1213,9 +1381,17 @@ export async function listGlobalSessions(): Promise<ChatSessionSummary[]> {
         const data = JSON.parse(row.value) as {
           name?: string;
           title?: string;
-          createdAt?: string;
-          updatedAt?: string;
+          createdAt?: string | number;
+          updatedAt?: string | number;
+          lastUpdatedAt?: string | number;
           workspaceUri?: string;
+          workspaceIdentifier?: {
+            uri?: {
+              fsPath?: string;
+              path?: string;
+              external?: string;
+            };
+          };
         };
 
         // Count bubbles for this composer
@@ -1240,17 +1416,23 @@ export async function listGlobalSessions(): Promise<ChatSessionSummary[]> {
           }
         }
 
-        const createdAt = data.createdAt ? new Date(data.createdAt) : new Date();
-        const workspacePath = data.workspaceUri
-          ? data.workspaceUri.replace(/^file:\/\//, '').replace(/%20/g, ' ')
-          : 'Global';
+        const createdAt = parseDateValue(data.createdAt) ?? new Date();
+        const workspacePath =
+          data.workspaceIdentifier?.uri?.fsPath ??
+          data.workspaceIdentifier?.uri?.path ??
+          (data.workspaceIdentifier?.uri?.external
+            ? uriToPath(data.workspaceIdentifier.uri.external)
+            : data.workspaceUri
+              ? uriToPath(data.workspaceUri)
+              : 'Global');
 
         sessions.push({
           id: composerId,
           index: 0,
           title: data.name ?? data.title ?? null,
           createdAt,
-          lastUpdatedAt: data.updatedAt ? new Date(data.updatedAt) : createdAt,
+          lastUpdatedAt:
+            parseDateValue(data.lastUpdatedAt) ?? parseDateValue(data.updatedAt) ?? createdAt,
           messageCount: bubbleCount.count,
           workspaceId: 'global',
           workspacePath: contractPath(workspacePath),
@@ -2341,12 +2523,22 @@ export function getComposerData(db: Database): ComposerDataResult | null {
             .filter((id): id is string => typeof id === 'string' && id.trim().length > 0)
             .map((id) => ({ composerId: id }))
         : [];
+      const allComposers = Array.isArray(data.allComposers) ? data.allComposers : [];
+      const seenIds = new Set(
+        allComposers
+          .map((composer) => composer.composerId)
+          .filter((id): id is string => typeof id === 'string' && id.trim().length > 0)
+      );
+      const missingSelectedComposers = selectedComposers.filter((composer) => {
+        if (!composer.composerId || seenIds.has(composer.composerId)) {
+          return false;
+        }
+        seenIds.add(composer.composerId);
+        return true;
+      });
 
       return {
-        composers:
-          Array.isArray(data.allComposers) && data.allComposers.length > 0
-            ? data.allComposers
-            : selectedComposers,
+        composers: [...allComposers, ...missingSelectedComposers],
         rawData,
         isNewFormat: true,
       };
@@ -2402,18 +2594,31 @@ export function updateComposerData(
     if (originalRawData && typeof originalRawData === 'object') {
       const original = originalRawData as Record<string, unknown>;
       const selectedOnly =
-        Array.isArray(original['selectedComposerIds']) && !Array.isArray(original['allComposers']);
+        Array.isArray(original['selectedComposerIds']) &&
+        (!Array.isArray(original['allComposers']) || original['allComposers'].length === 0);
       const nextData: Record<string, unknown> = { ...original, allComposers: composers };
 
-      if (selectedOnly) {
-        const selectedComposerIds = composers
+      if (Array.isArray(original['selectedComposerIds'])) {
+        const composerIds = composers
           .map((composer) => composer.composerId)
           .filter((id): id is string => typeof id === 'string' && id.trim().length > 0);
+        const composerIdSet = new Set(composerIds);
+        const originalSelected = original['selectedComposerIds'].filter(
+          (id): id is string => typeof id === 'string' && id.trim().length > 0
+        );
+        const selectedComposerIds = selectedOnly
+          ? composerIds
+          : originalSelected.filter((id) => composerIdSet.has(id));
         nextData['selectedComposerIds'] = selectedComposerIds;
 
         if (Array.isArray(original['lastFocusedComposerIds'])) {
-          nextData['lastFocusedComposerIds'] =
-            selectedComposerIds.length > 0 ? [selectedComposerIds[0]!] : [];
+          const originalFocused = original['lastFocusedComposerIds'].filter(
+            (id): id is string => typeof id === 'string' && id.trim().length > 0
+          );
+          const focusedComposerIds = selectedOnly
+            ? selectedComposerIds.slice(0, 1)
+            : originalFocused.filter((id) => composerIdSet.has(id));
+          nextData['lastFocusedComposerIds'] = focusedComposerIds;
         }
       }
 

--- a/src/core/storage.ts
+++ b/src/core/storage.ts
@@ -4,8 +4,7 @@
 
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
-import { join, dirname } from 'node:path';
-import { homedir } from 'node:os';
+import { join } from 'node:path';
 import JSZip from 'jszip';
 import {
   openDatabase as openDatabaseAsync,
@@ -26,7 +25,13 @@ import type {
   SessionUsage,
   ContextWindowStatus,
 } from './types.js';
-import { getCursorDataPath, contractPath, normalizePath, pathsEqual } from '../lib/platform.js';
+import {
+  getCursorDataPath,
+  getGlobalStoragePath,
+  contractPath,
+  normalizePath,
+  pathsEqual,
+} from '../lib/platform.js';
 import { SessionNotFoundError } from '../lib/errors.js';
 import { parseChatData, getSearchSnippets, type CursorChatBundle } from './parser.js';
 import { openBackupDatabase, readBackupManifest } from './backup.js';
@@ -46,36 +51,6 @@ const CHAT_DATA_KEYS = [
  */
 const PROMPTS_KEY = 'aiService.prompts';
 const GENERATIONS_KEY = 'aiService.generations';
-
-/**
- * Get the global Cursor storage path
- */
-function getGlobalStoragePath(customDataPath?: string): string {
-  // Global storage sits next to workspaceStorage under `.../User/`. When a custom
-  // data path (flag or CURSOR_DATA_PATH) is in effect, derive global storage from
-  // that same root instead of the machine default — otherwise an empty or foreign
-  // `--data-path` would still enumerate the local profile's default global DB.
-  const dataPath = customDataPath ?? process.env['CURSOR_DATA_PATH'];
-  if (dataPath) {
-    return join(dirname(dataPath), 'globalStorage');
-  }
-
-  const platform = process.platform;
-  const home = homedir();
-
-  if (platform === 'win32') {
-    return join(
-      process.env['APPDATA'] ?? join(home, 'AppData', 'Roaming'),
-      'Cursor',
-      'User',
-      'globalStorage'
-    );
-  } else if (platform === 'darwin') {
-    return join(home, 'Library', 'Application Support', 'Cursor', 'User', 'globalStorage');
-  } else {
-    return join(home, '.config', 'Cursor', 'User', 'globalStorage');
-  }
-}
 
 /**
  * Open a SQLite database file (read-only)
@@ -1443,7 +1418,7 @@ export async function getSession(
   // This works for both live data and backup (if backup includes globalStorage)
   let globalDb: Database | null = null;
   let globalLoadFailed = false;
-  const globalDbPath = join(getGlobalStoragePath(), 'state.vscdb');
+  const globalDbPath = join(getGlobalStoragePath(customDataPath), 'state.vscdb');
 
   try {
     if (backupPath) {
@@ -1625,8 +1600,8 @@ export async function searchSessions(
  * List sessions from global Cursor storage (cursorDiskKV table)
  * This is where Cursor stores full conversation data including AI responses
  */
-export async function listGlobalSessions(): Promise<ChatSessionSummary[]> {
-  const globalPath = getGlobalStoragePath();
+export async function listGlobalSessions(customDataPath?: string): Promise<ChatSessionSummary[]> {
+  const globalPath = getGlobalStoragePath(customDataPath);
   const dbPath = join(globalPath, 'state.vscdb');
 
   if (!existsSync(dbPath)) {
@@ -1741,15 +1716,18 @@ export async function listGlobalSessions(): Promise<ChatSessionSummary[]> {
 /**
  * Get a session from global storage by index
  */
-export async function getGlobalSession(index: number): Promise<ChatSession | null> {
-  const summaries = await listGlobalSessions();
+export async function getGlobalSession(
+  index: number,
+  customDataPath?: string
+): Promise<ChatSession | null> {
+  const summaries = await listGlobalSessions(customDataPath);
   const summary = summaries.find((s) => s.index === index);
 
   if (!summary) {
     return null;
   }
 
-  const globalPath = getGlobalStoragePath();
+  const globalPath = getGlobalStoragePath(customDataPath);
   const dbPath = join(globalPath, 'state.vscdb');
   let db: Database | null = null;
 

--- a/src/core/storage.ts
+++ b/src/core/storage.ts
@@ -4,7 +4,7 @@
 
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import JSZip from 'jszip';
 import {
@@ -50,7 +50,16 @@ const GENERATIONS_KEY = 'aiService.generations';
 /**
  * Get the global Cursor storage path
  */
-function getGlobalStoragePath(): string {
+function getGlobalStoragePath(customDataPath?: string): string {
+  // Global storage sits next to workspaceStorage under `.../User/`. When a custom
+  // data path (flag or CURSOR_DATA_PATH) is in effect, derive global storage from
+  // that same root instead of the machine default — otherwise an empty or foreign
+  // `--data-path` would still enumerate the local profile's default global DB.
+  const dataPath = customDataPath ?? process.env['CURSOR_DATA_PATH'];
+  if (dataPath) {
+    return join(dirname(dataPath), 'globalStorage');
+  }
+
   const platform = process.platform;
   const home = homedir();
 
@@ -770,7 +779,7 @@ export async function findWorkspaces(
 
       if (!globalDbChecked) {
         globalDbChecked = true;
-        const globalDbPath = join(getGlobalStoragePath(), 'state.vscdb');
+        const globalDbPath = join(getGlobalStoragePath(customDataPath), 'state.vscdb');
         if (existsSync(globalDbPath)) {
           try {
             globalDb = await openDatabase(globalDbPath);
@@ -1082,8 +1091,11 @@ function getGlobalComposerSummariesForWorkspace(
  * sessions discoverable only through global storage are migrated too, matching
  * what `list` surfaces for the workspace.
  */
-export async function getWorkspaceLinkedComposerIds(workspace: Workspace): Promise<string[]> {
-  const globalDbPath = join(getGlobalStoragePath(), 'state.vscdb');
+export async function getWorkspaceLinkedComposerIds(
+  workspace: Workspace,
+  customDataPath?: string
+): Promise<string[]> {
+  const globalDbPath = join(getGlobalStoragePath(customDataPath), 'state.vscdb');
   if (!existsSync(globalDbPath)) {
     return [];
   }
@@ -1243,7 +1255,7 @@ export async function listSessions(
   }
 
   if (!backupPath && (globalFallbackCandidates.length > 0 || !options.workspacePath)) {
-    const globalDbPath = join(getGlobalStoragePath(), 'state.vscdb');
+    const globalDbPath = join(getGlobalStoragePath(customDataPath), 'state.vscdb');
     if (existsSync(globalDbPath)) {
       let globalDb: Database | null = null;
       try {

--- a/src/core/storage.ts
+++ b/src/core/storage.ts
@@ -129,6 +129,11 @@ interface WorkspaceGlobalCandidate {
   includeWorkspaceLinked: boolean;
 }
 
+interface GlobalComposerRecord {
+  id: string;
+  data: Record<string, unknown>;
+}
+
 function getErrorMessage(error: unknown): string {
   if (error instanceof Error && error.message) {
     return error.message;
@@ -156,12 +161,26 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value);
 }
 
+/**
+ * A composer entry carries real metadata when it has any field beyond `composerId`.
+ * Synthetic `{ composerId }` stubs (fabricated from `selectedComposerIds` by
+ * getComposerData) must never be persisted back into `allComposers`, or they would
+ * parse to phantom sessions with a null title and a "now" timestamp.
+ */
+function isHydratedComposer(composer: { composerId?: string; [key: string]: unknown }): boolean {
+  return Object.keys(composer).some((key) => key !== 'composerId');
+}
+
 function parseDateValue(value: unknown): Date | null {
   if (typeof value !== 'string' && typeof value !== 'number') {
     return null;
   }
 
-  const date = new Date(value);
+  // Epoch-ms timestamps can arrive as numeric strings ("1778672423842"); new Date()
+  // treats those as invalid, so coerce all-digit strings to a number first.
+  const normalized =
+    typeof value === 'string' && /^\d+$/.test(value.trim()) ? Number(value.trim()) : value;
+  const date = new Date(normalized);
   return Number.isNaN(date.getTime()) ? null : date;
 }
 
@@ -638,6 +657,10 @@ export async function findWorkspaces(
   let globalDb: Database | null = null;
   let globalDbChecked = false;
   let globalDbAvailable = false;
+  let globalComposerRecords: GlobalComposerRecord[] = [];
+  // Run-level set so a global composer is counted for at most one workspace,
+  // keeping `list --workspaces` counts consistent with the deduped `list` output.
+  const attributedComposerIds = new Set<string>();
 
   try {
     const entries = readdirSync(basePath, { withFileTypes: true });
@@ -667,6 +690,7 @@ export async function findWorkspaces(
           sessionCount = parsed.length;
           for (const session of parsed) {
             seenComposerIds.add(session.id);
+            attributedComposerIds.add(session.id);
           }
 
           const rawComposerData = result.bundle.composerData;
@@ -696,6 +720,9 @@ export async function findWorkspaces(
               .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='cursorDiskKV'")
               .get();
             globalDbAvailable = Boolean(tableCheck);
+            if (globalDbAvailable) {
+              globalComposerRecords = loadGlobalComposerRecords(globalDb);
+            }
           } catch {
             closeDatabase(globalDb);
             globalDb = null;
@@ -706,9 +733,10 @@ export async function findWorkspaces(
 
       if (globalDb && globalDbAvailable) {
         for (const composerId of selectedIds) {
-          if (seenComposerIds.has(composerId)) continue;
+          if (seenComposerIds.has(composerId) || attributedComposerIds.has(composerId)) continue;
           if (countGlobalBubblesForComposerId(globalDb, composerId) > 0) {
             seenComposerIds.add(composerId);
+            attributedComposerIds.add(composerId);
             sessionCount++;
           }
         }
@@ -721,16 +749,19 @@ export async function findWorkspaces(
         };
         for (const summary of getGlobalComposerSummariesForWorkspace(
           globalDb,
-          workspaceForGlobalMatch
+          workspaceForGlobalMatch,
+          globalComposerRecords
         )) {
-          if (seenComposerIds.has(summary.id)) continue;
+          if (seenComposerIds.has(summary.id) || attributedComposerIds.has(summary.id)) continue;
           seenComposerIds.add(summary.id);
+          attributedComposerIds.add(summary.id);
           sessionCount++;
         }
       } else {
         for (const composerId of selectedIds) {
-          if (seenComposerIds.has(composerId)) continue;
+          if (seenComposerIds.has(composerId) || attributedComposerIds.has(composerId)) continue;
           seenComposerIds.add(composerId);
+          attributedComposerIds.add(composerId);
           sessionCount++;
         }
       }
@@ -892,36 +923,90 @@ function getGlobalComposerSummary(db: Database, composerId: string): GlobalCompo
   }
 }
 
-function getGlobalComposerSummariesForWorkspace(
-  db: Database,
-  workspace: Workspace
-): GlobalComposerSummary[] {
+/**
+ * Load and parse every `composerData:%` row from global storage exactly once.
+ * Callers reuse the result across all workspaces instead of re-scanning and
+ * re-parsing the full composer table per workspace (which made `list` O(W×C)).
+ */
+function loadGlobalComposerRecords(db: Database): GlobalComposerRecord[] {
   try {
     const rows = db
       .prepare("SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%'")
       .all() as { key: string; value: string }[];
-    const summaries: GlobalComposerSummary[] = [];
+    const records: GlobalComposerRecord[] = [];
 
     for (const row of rows) {
-      const composerId = row.key.replace('composerData:', '');
       try {
-        const composerData = JSON.parse(row.value) as unknown;
-        if (!isRecord(composerData) || !composerBelongsToWorkspace(composerData, workspace)) {
-          continue;
-        }
-
-        const summary = buildGlobalComposerSummary(db, composerId, composerData);
-        if (summary) {
-          summaries.push(summary);
+        const data = JSON.parse(row.value) as unknown;
+        if (isRecord(data)) {
+          records.push({ id: row.key.replace('composerData:', ''), data });
         }
       } catch {
         continue;
       }
     }
 
-    return summaries;
+    return records;
   } catch {
     return [];
+  }
+}
+
+function getGlobalComposerSummariesForWorkspace(
+  db: Database,
+  workspace: Workspace,
+  records: GlobalComposerRecord[]
+): GlobalComposerSummary[] {
+  const summaries: GlobalComposerSummary[] = [];
+
+  for (const record of records) {
+    if (!composerBelongsToWorkspace(record.data, workspace)) {
+      continue;
+    }
+
+    const summary = buildGlobalComposerSummary(db, record.id, record.data);
+    if (summary) {
+      summaries.push(summary);
+    }
+  }
+
+  return summaries;
+}
+
+/**
+ * Return the composer IDs whose global-storage record is linked to `workspace`
+ * (via workspaceIdentifier or workspaceUri). Used by workspace migration so that
+ * sessions discoverable only through global storage are migrated too, matching
+ * what `list` surfaces for the workspace.
+ */
+export async function getWorkspaceLinkedComposerIds(workspace: Workspace): Promise<string[]> {
+  const globalDbPath = join(getGlobalStoragePath(), 'state.vscdb');
+  if (!existsSync(globalDbPath)) {
+    return [];
+  }
+
+  let db: Database | null = null;
+  try {
+    db = await openDatabase(globalDbPath);
+    const tableCheck = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='cursorDiskKV'")
+      .get();
+    if (!tableCheck) {
+      return [];
+    }
+
+    const ids: string[] = [];
+    for (const record of loadGlobalComposerRecords(db)) {
+      if (composerBelongsToWorkspace(record.data, workspace)) {
+        ids.push(record.id);
+      }
+    }
+    return ids;
+  } catch (error) {
+    debugLogStorage(`Failed to load workspace-linked composer IDs: ${getErrorMessage(error)}`);
+    return [];
+  } finally {
+    closeDatabase(db);
   }
 }
 
@@ -1036,11 +1121,17 @@ export async function listSessions(
           .get();
 
         if (tableCheck) {
+          const globalComposerRecords = loadGlobalComposerRecords(globalDb);
           const summaryCache = new Map<string, GlobalComposerSummary | null>();
+          // Dedup recovered sessions across candidates even under `--workspace`
+          // (where the shared `seenIds` is intentionally null), so a single global
+          // composer matching multiple workspace dirs is listed at most once.
+          const recoveredIds = new Set<string>();
           for (const candidate of globalFallbackCandidates) {
             for (const composerId of candidate.composerIds) {
               if (candidate.existingIds.has(composerId)) continue;
               if (seenIds?.has(composerId)) continue;
+              if (recoveredIds.has(composerId)) continue;
 
               if (!summaryCache.has(composerId)) {
                 summaryCache.set(composerId, getGlobalComposerSummary(globalDb, composerId));
@@ -1053,6 +1144,7 @@ export async function listSessions(
 
               candidate.existingIds.add(summary.id);
               seenIds?.add(summary.id);
+              recoveredIds.add(summary.id);
               allSessions.push({
                 id: summary.id,
                 index: 0,
@@ -1069,13 +1161,16 @@ export async function listSessions(
             if (candidate.includeWorkspaceLinked) {
               for (const summary of getGlobalComposerSummariesForWorkspace(
                 globalDb,
-                candidate.workspace
+                candidate.workspace,
+                globalComposerRecords
               )) {
                 if (candidate.existingIds.has(summary.id)) continue;
                 if (seenIds?.has(summary.id)) continue;
+                if (recoveredIds.has(summary.id)) continue;
 
                 candidate.existingIds.add(summary.id);
                 seenIds?.add(summary.id);
+                recoveredIds.add(summary.id);
                 allSessions.push({
                   id: summary.id,
                   index: 0,
@@ -2596,7 +2691,13 @@ export function updateComposerData(
       const selectedOnly =
         Array.isArray(original['selectedComposerIds']) &&
         (!Array.isArray(original['allComposers']) || original['allComposers'].length === 0);
-      const nextData: Record<string, unknown> = { ...original, allComposers: composers };
+      // Only persist composers that carry real metadata. Synthetic `{ composerId }`
+      // stubs (surfaced by getComposerData's union of selectedComposerIds) would
+      // otherwise be written back and parse to phantom sessions on the next list.
+      const nextData: Record<string, unknown> = {
+        ...original,
+        allComposers: composers.filter(isHydratedComposer),
+      };
 
       if (Array.isArray(original['selectedComposerIds'])) {
         const composerIds = composers
@@ -2615,16 +2716,32 @@ export function updateComposerData(
           const originalFocused = original['lastFocusedComposerIds'].filter(
             (id): id is string => typeof id === 'string' && id.trim().length > 0
           );
-          const focusedComposerIds = selectedOnly
-            ? selectedComposerIds.slice(0, 1)
-            : originalFocused.filter((id) => composerIdSet.has(id));
+          // Keep the previously focused tab whenever it survives the change;
+          // only fall back to the first surviving composer when it does not.
+          const survivingFocused = originalFocused.filter((id) => composerIdSet.has(id));
+          const focusedComposerIds =
+            survivingFocused.length > 0
+              ? survivingFocused
+              : selectedOnly
+                ? selectedComposerIds.slice(0, 1)
+                : [];
           nextData['lastFocusedComposerIds'] = focusedComposerIds;
         }
       }
 
       dataToWrite = nextData;
     } else {
-      dataToWrite = { allComposers: composers };
+      // No original shape to preserve: write only real composers, but keep any
+      // id-only stubs referenced via selectedComposerIds so they remain listable.
+      const hydrated = composers.filter(isHydratedComposer);
+      const stubIds = composers
+        .filter((composer) => !isHydratedComposer(composer))
+        .map((composer) => composer.composerId)
+        .filter((id): id is string => typeof id === 'string' && id.trim().length > 0);
+      dataToWrite =
+        stubIds.length > 0
+          ? { allComposers: hydrated, selectedComposerIds: stubIds }
+          : { allComposers: hydrated };
     }
   } else {
     // Legacy format - direct array

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -3,7 +3,7 @@
  */
 
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import type { Platform } from '../core/types.js';
 
 /**
@@ -63,6 +63,13 @@ export function getCursorDataPath(customPath?: string): string {
   }
 
   return getDefaultCursorDataPath();
+}
+
+/**
+ * Get the Cursor global storage path for the active workspaceStorage root.
+ */
+export function getGlobalStoragePath(customDataPath?: string): string {
+  return join(dirname(getCursorDataPath(customDataPath)), 'globalStorage');
 }
 
 /**

--- a/tests/unit/migrate.test.ts
+++ b/tests/unit/migrate.test.ts
@@ -260,7 +260,7 @@ describe('migrateSession', () => {
                 value: JSON.stringify({
                   name: 'Hydrated Session',
                   createdAt: 1777583348738,
-                  updatedAt: 1777584322685,
+                  lastUpdatedAt: 1777584322685,
                 }),
               };
             }
@@ -283,6 +283,7 @@ describe('migrateSession', () => {
     const destComposers = mockUpdateComposerData.mock.calls[1]![1] as Array<Record<string, unknown>>;
     expect(destComposers[0]?.['name']).toBe('Hydrated Session');
     expect(destComposers[0]?.['createdAt']).toBe(1777583348738);
+    expect(destComposers[0]?.['lastUpdatedAt']).toBe(1777584322685);
   });
 
   it('returns failure result when DB operation throws', async () => {
@@ -447,6 +448,54 @@ describe('migrateWorkspace', () => {
     expect(result.dryRun).toBe(true);
   });
 
+  it('does not silently filter bubble-less header-only sessions', async () => {
+    mockFindWorkspaceByPath.mockImplementation(async (path: string) => {
+      if (path === '/source') {
+        return {
+          workspace: { id: 'source-ws', path: '/source', dbPath: '/db1', sessionCount: 2 },
+          dbPath: '/db1',
+        };
+      }
+      return {
+        workspace: { id: 'dest-ws', path: '/dest', dbPath: '/db2', sessionCount: 0 },
+        dbPath: '/db2',
+      };
+    });
+
+    const db = createMockDb();
+    mockOpenDatabaseReadWrite.mockResolvedValue(db);
+    mockGetComposerData.mockReturnValueOnce({
+      composers: [{ composerId: 's1' }, { composerId: 's2' }],
+      isNewFormat: true,
+      rawData: { selectedComposerIds: ['s1', 's2'] },
+    });
+
+    vi.mocked(existsSync).mockImplementation((p) => String(p).includes('globalStorage'));
+    vi.mocked(BetterSqlite3).mockImplementation(function () {
+      return {
+        prepare: vi.fn(() => ({
+          get: vi.fn((pattern?: string) => ({
+            count: String(pattern).includes('s1') ? 1 : 0,
+          })),
+          all: vi.fn(() => []),
+          run: vi.fn(),
+        })),
+        close: vi.fn(),
+      } as any;
+    } as any);
+
+    const result = await migrateWorkspace({
+      source: '/source',
+      destination: '/dest',
+      mode: 'move',
+      dryRun: true,
+      force: true,
+    });
+
+    expect(result.totalSessions).toBe(2);
+    expect(result.results.map((r) => r.sessionId)).toEqual(['s1', 's2']);
+  });
+
   it('throws NestedPathError for nested paths', async () => {
     await expect(
       migrateWorkspace({
@@ -484,7 +533,10 @@ describe('migrateSession - global storage path transformation (copy mode)', () =
       workspace: { id: 'ws1', path: '/source/project', dbPath: '/db1', sessionCount: 1 },
       dbPath: '/db1',
     });
-    mockFindWorkspaceByPath.mockResolvedValue({ dbPath: '/db2' });
+    mockFindWorkspaceByPath.mockResolvedValue({
+      workspace: { id: 'dest-ws', path: '/dest/project', dbPath: '/db2', sessionCount: 0 },
+      dbPath: '/db2',
+    });
 
     const sourceDb = createMockDb();
     const destDb = createMockDb();
@@ -514,6 +566,15 @@ describe('migrateSession - global storage path transformation (copy mode)', () =
     // Setup BetterSqlite3 mock with bubble data containing paths
     const composerDataValue = JSON.stringify({
       composerId: 'sid',
+      workspaceIdentifier: {
+        id: 'source-ws',
+        uri: {
+          fsPath: '/source/project',
+          external: 'file:///source/project',
+          path: '/source/project',
+          scheme: 'file',
+        },
+      },
       fullConversationHeadersOnly: [
         { bubbleId: 'b1', type: 2 },
         { bubbleId: 'b2', type: 1 },
@@ -591,6 +652,9 @@ describe('migrateSession - global storage path transformation (copy mode)', () =
     expect(composerInsertCall).toBeDefined();
     const insertedComposer = JSON.parse(String(composerInsertCall![1]));
     expect(insertedComposer.workspaceUri).toBe('file:///dest/project');
+    expect(insertedComposer.workspaceIdentifier.id).toBe('dest-ws');
+    expect(insertedComposer.workspaceIdentifier.uri.fsPath).toBe('/dest/project');
+    expect(insertedComposer.workspaceIdentifier.uri.external).toBe('file:///dest/project');
 
     // Check bubble insert has transformed paths
     // run() is called as run(key, value) - find the call where key starts with 'bubbleId:'
@@ -817,7 +881,10 @@ describe('migrateSession - global storage path transformation (move mode)', () =
       workspace: { id: 'ws1', path: '/source/project', dbPath: '/db1', sessionCount: 1 },
       dbPath: '/db1',
     });
-    mockFindWorkspaceByPath.mockResolvedValue({ dbPath: '/db2' });
+    mockFindWorkspaceByPath.mockResolvedValue({
+      workspace: { id: 'dest-ws', path: '/dest/project', dbPath: '/db2', sessionCount: 0 },
+      dbPath: '/db2',
+    });
 
     const sourceDb = createMockDb();
     const destDb = createMockDb();
@@ -846,6 +913,15 @@ describe('migrateSession - global storage path transformation (move mode)', () =
     const composerDataValue = JSON.stringify({
       composerId: 'sid',
       workspaceUri: 'file:///source/project',
+      workspaceIdentifier: {
+        id: 'source-ws',
+        uri: {
+          fsPath: '/source/project',
+          external: 'file:///source/project',
+          path: '/source/project',
+          scheme: 'file',
+        },
+      },
       fullConversationHeadersOnly: [{ bubbleId: 'b1', type: 2 }],
     });
     const bubbleWithPaths = JSON.stringify({
@@ -895,6 +971,9 @@ describe('migrateSession - global storage path transformation (move mode)', () =
     expect(composerUpdateCall).toBeDefined();
     const updatedComposer = JSON.parse(String(composerUpdateCall![0]));
     expect(updatedComposer.workspaceUri).toBe('file:///dest/project');
+    expect(updatedComposer.workspaceIdentifier.id).toBe('dest-ws');
+    expect(updatedComposer.workspaceIdentifier.uri.fsPath).toBe('/dest/project');
+    expect(updatedComposer.workspaceIdentifier.uri.external).toBe('file:///dest/project');
   });
 });
 

--- a/tests/unit/migrate.test.ts
+++ b/tests/unit/migrate.test.ts
@@ -6,6 +6,7 @@ const mockFindWorkspaceByPath = vi.fn();
 const mockOpenDatabaseReadWrite = vi.fn();
 const mockGetComposerData = vi.fn();
 const mockUpdateComposerData = vi.fn();
+const mockGetWorkspaceLinkedComposerIds = vi.fn();
 
 vi.mock('../../src/core/storage.js', () => ({
   findWorkspaceForSession: (...args: unknown[]) => mockFindWorkspaceForSession(...args),
@@ -13,6 +14,7 @@ vi.mock('../../src/core/storage.js', () => ({
   openDatabaseReadWrite: (...args: unknown[]) => mockOpenDatabaseReadWrite(...args),
   getComposerData: (...args: unknown[]) => mockGetComposerData(...args),
   updateComposerData: (...args: unknown[]) => mockUpdateComposerData(...args),
+  getWorkspaceLinkedComposerIds: (...args: unknown[]) => mockGetWorkspaceLinkedComposerIds(...args),
 }));
 
 // Mock platform functions
@@ -53,6 +55,8 @@ beforeEach(() => {
   mockOpenDatabaseReadWrite.mockReset();
   mockGetComposerData.mockReset();
   mockUpdateComposerData.mockReset();
+  mockGetWorkspaceLinkedComposerIds.mockReset();
+  mockGetWorkspaceLinkedComposerIds.mockResolvedValue([]);
   vi.mocked(existsSync).mockReset();
   vi.mocked(existsSync).mockReturnValue(false);
   vi.mocked(BetterSqlite3).mockReset();
@@ -286,6 +290,73 @@ describe('migrateSession', () => {
     expect(destComposers[0]?.['lastUpdatedAt']).toBe(1777584322685);
   });
 
+  it('move mode migrates a session that exists only in global storage (not in source composers)', async () => {
+    mockFindWorkspaceForSession.mockResolvedValue({
+      workspace: { id: 'ws1', path: '/source', dbPath: '/db1', sessionCount: 1 },
+      dbPath: '/db1',
+    });
+    mockFindWorkspaceByPath.mockResolvedValue({
+      workspace: { id: 'dest-ws', path: '/dest', dbPath: '/db2', sessionCount: 0 },
+      dbPath: '/db2',
+    });
+
+    const sourceDb = createMockDb();
+    const destDb = createMockDb();
+    let callCount = 0;
+    mockOpenDatabaseReadWrite.mockImplementation(async () => {
+      callCount++;
+      return callCount === 1 ? sourceDb : destDb;
+    });
+
+    // Source workspace composer list does NOT contain 'global-sid'.
+    mockGetComposerData
+      .mockReturnValueOnce({
+        composers: [{ composerId: 'other' }],
+        isNewFormat: true,
+        rawData: { selectedComposerIds: ['other'] },
+      })
+      .mockReturnValueOnce({ composers: [], isNewFormat: true, rawData: {} });
+
+    vi.mocked(existsSync).mockImplementation((p) => String(p).includes('globalStorage'));
+    vi.mocked(BetterSqlite3).mockImplementation(function () {
+      return {
+        prepare: vi.fn((sql: string) => ({
+          get: vi.fn((...args: unknown[]) => {
+            const key = String(args[0]);
+            if (sql.includes('SELECT 1 FROM cursorDiskKV') && key.startsWith('composerData:')) {
+              return { 1: 1 };
+            }
+            if (
+              sql.includes('SELECT value FROM cursorDiskKV') &&
+              key.startsWith('composerData:')
+            ) {
+              return {
+                value: JSON.stringify({ name: 'Global Only', createdAt: 1, lastUpdatedAt: 2 }),
+              };
+            }
+            return undefined;
+          }),
+          all: vi.fn(() => []),
+          run: vi.fn(),
+        })),
+        close: vi.fn(),
+      } as any;
+    } as any);
+
+    const result = await migrateSession('global-sid', {
+      destination: '/dest',
+      mode: 'move',
+      dryRun: false,
+    });
+
+    expect(result.success).toBe(true);
+    // Source has no composer entry to remove, so updateComposerData runs only for dest.
+    expect(mockUpdateComposerData).toHaveBeenCalledTimes(1);
+    const destComposers = mockUpdateComposerData.mock.calls[0]![1] as Array<Record<string, unknown>>;
+    expect(destComposers[0]?.['composerId']).toBe('global-sid');
+    expect(destComposers[0]?.['name']).toBe('Global Only');
+  });
+
   it('returns failure result when DB operation throws', async () => {
     mockFindWorkspaceForSession.mockResolvedValue({
       workspace: { id: 'ws1', path: '/source', dbPath: '/db1', sessionCount: 1 },
@@ -494,6 +565,40 @@ describe('migrateWorkspace', () => {
 
     expect(result.totalSessions).toBe(2);
     expect(result.results.map((r) => r.sessionId)).toEqual(['s1', 's2']);
+  });
+
+  it('migrates sessions discoverable only via global storage (workspaceIdentifier-linked)', async () => {
+    mockFindWorkspaceByPath.mockImplementation(async (path: string) => {
+      if (path === '/source') {
+        return {
+          workspace: { id: 'source-ws', path: '/source', dbPath: '/db1', sessionCount: 1 },
+          dbPath: '/db1',
+        };
+      }
+      return {
+        workspace: { id: 'dest-ws', path: '/dest', dbPath: '/db2', sessionCount: 0 },
+        dbPath: '/db2',
+      };
+    });
+    mockOpenDatabaseReadWrite.mockResolvedValue(createMockDb());
+    mockGetComposerData.mockReturnValueOnce({
+      composers: [{ composerId: 's1' }],
+      isNewFormat: true,
+      rawData: { selectedComposerIds: ['s1'] },
+    });
+    // Global storage links an extra session ('global-only-1') to the source workspace.
+    mockGetWorkspaceLinkedComposerIds.mockResolvedValue(['s1', 'global-only-1']);
+
+    const result = await migrateWorkspace({
+      source: '/source',
+      destination: '/dest',
+      mode: 'move',
+      dryRun: true,
+      force: true,
+    });
+
+    expect(result.totalSessions).toBe(2);
+    expect([...result.results.map((r) => r.sessionId)].sort()).toEqual(['global-only-1', 's1']);
   });
 
   it('throws NestedPathError for nested paths', async () => {

--- a/tests/unit/migrate.test.ts
+++ b/tests/unit/migrate.test.ts
@@ -48,7 +48,20 @@ function createMockDb() {
 }
 
 beforeEach(() => {
-  vi.clearAllMocks();
+  mockFindWorkspaceForSession.mockReset();
+  mockFindWorkspaceByPath.mockReset();
+  mockOpenDatabaseReadWrite.mockReset();
+  mockGetComposerData.mockReset();
+  mockUpdateComposerData.mockReset();
+  vi.mocked(existsSync).mockReset();
+  vi.mocked(existsSync).mockReturnValue(false);
+  vi.mocked(BetterSqlite3).mockReset();
+  vi.mocked(BetterSqlite3).mockImplementation(function () {
+    return {
+      prepare: vi.fn(() => ({ get: vi.fn(), all: vi.fn(() => []), run: vi.fn() })),
+      close: vi.fn(),
+    } as any;
+  } as any);
 });
 
 // =============================================================================
@@ -205,6 +218,71 @@ describe('migrateSession', () => {
     expect(result.newSessionId).toBeDefined();
     // Only dest DB should be updated (source untouched in copy mode)
     expect(mockUpdateComposerData).toHaveBeenCalledTimes(1);
+  });
+
+  it('move mode hydrates composer headers from global composerData', async () => {
+    mockFindWorkspaceForSession.mockResolvedValue({
+      workspace: { id: 'ws1', path: '/source', dbPath: '/db1', sessionCount: 1 },
+      dbPath: '/db1',
+    });
+    mockFindWorkspaceByPath.mockResolvedValue({ dbPath: '/db2' });
+
+    const sourceDb = createMockDb();
+    const destDb = createMockDb();
+    let callCount = 0;
+    mockOpenDatabaseReadWrite.mockImplementation(async () => {
+      callCount++;
+      return callCount === 1 ? sourceDb : destDb;
+    });
+
+    mockGetComposerData
+      .mockReturnValueOnce({
+        composers: [{ composerId: 'sid' }],
+        isNewFormat: true,
+        rawData: { selectedComposerIds: ['sid'] },
+      })
+      .mockReturnValueOnce({
+        composers: [],
+        isNewFormat: true,
+        rawData: {},
+      });
+
+    vi.mocked(existsSync).mockImplementation((p) => String(p).includes('globalStorage'));
+    vi.mocked(BetterSqlite3).mockImplementation(function () {
+      return {
+        prepare: vi.fn((sql: string) => ({
+          get: vi.fn((...args: unknown[]) => {
+            if (
+              sql.includes('SELECT value FROM cursorDiskKV') &&
+              String(args[0]).startsWith('composerData:')
+            ) {
+              return {
+                value: JSON.stringify({
+                  name: 'Hydrated Session',
+                  createdAt: 1777583348738,
+                  updatedAt: 1777584322685,
+                }),
+              };
+            }
+            return undefined;
+          }),
+          all: vi.fn(() => []),
+          run: vi.fn(),
+        })),
+        close: vi.fn(),
+      } as any;
+    } as any);
+
+    const result = await migrateSession('sid', {
+      destination: '/dest',
+      mode: 'move',
+      dryRun: false,
+    });
+
+    expect(result.success).toBe(true);
+    const destComposers = mockUpdateComposerData.mock.calls[1]![1] as Array<Record<string, unknown>>;
+    expect(destComposers[0]?.['name']).toBe('Hydrated Session');
+    expect(destComposers[0]?.['createdAt']).toBe(1777583348738);
   });
 
   it('returns failure result when DB operation throws', async () => {
@@ -507,6 +585,13 @@ describe('migrateSession - global storage path transformation (copy mode)', () =
     // There should be at least 2 INSERT calls (composerData + bubble)
     expect(insertCalls.length).toBeGreaterThanOrEqual(2);
 
+    const composerInsertCall = insertCalls.find((call: unknown[]) => {
+      return String(call[0] || '').startsWith('composerData:');
+    });
+    expect(composerInsertCall).toBeDefined();
+    const insertedComposer = JSON.parse(String(composerInsertCall![1]));
+    expect(insertedComposer.workspaceUri).toBe('file:///dest/project');
+
     // Check bubble insert has transformed paths
     // run() is called as run(key, value) - find the call where key starts with 'bubbleId:'
     const bubbleInsertCall = insertCalls.find((call: unknown[]) => {
@@ -725,6 +810,91 @@ describe('migrateSession - global storage path transformation (move mode)', () =
     expect(updatedValue.codeBlocks[0].uri.path).toBe('/dest/project/src/app.ts');
     expect(updatedValue.codeBlocks[0].uri._fsPath).toBe('/dest/project/src/app.ts');
     expect(updatedValue.codeBlocks[0].uri._formatted).toBe('file:///dest/project/src/app.ts');
+  });
+
+  it('move mode: updates global composerData workspaceUri to destination', async () => {
+    mockFindWorkspaceForSession.mockResolvedValue({
+      workspace: { id: 'ws1', path: '/source/project', dbPath: '/db1', sessionCount: 1 },
+      dbPath: '/db1',
+    });
+    mockFindWorkspaceByPath.mockResolvedValue({ dbPath: '/db2' });
+
+    const sourceDb = createMockDb();
+    const destDb = createMockDb();
+    let callCount = 0;
+    mockOpenDatabaseReadWrite.mockImplementation(async () => {
+      callCount++;
+      return callCount === 1 ? sourceDb : destDb;
+    });
+
+    mockGetComposerData
+      .mockReturnValueOnce({
+        composers: [{ composerId: 'sid', name: 'Session' }],
+        isNewFormat: true,
+        rawData: { selectedComposerIds: [] },
+      })
+      .mockReturnValueOnce({
+        composers: [],
+        isNewFormat: true,
+        rawData: {},
+      });
+
+    vi.mocked(existsSync).mockImplementation((p) => {
+      return String(p).includes('globalStorage');
+    });
+
+    const composerDataValue = JSON.stringify({
+      composerId: 'sid',
+      workspaceUri: 'file:///source/project',
+      fullConversationHeadersOnly: [{ bubbleId: 'b1', type: 2 }],
+    });
+    const bubbleWithPaths = JSON.stringify({
+      bubbleId: 'b1',
+      type: 2,
+      toolFormerData: {
+        name: 'read_file',
+        params: JSON.stringify({ targetFile: '/source/project/src/app.ts' }),
+      },
+    });
+
+    const mockRun = vi.fn();
+    vi.mocked(BetterSqlite3).mockImplementation(function () {
+      return {
+        prepare: vi.fn((sql: string) => ({
+          get: vi.fn((...args: unknown[]) => {
+            if (
+              sql.includes('SELECT value FROM cursorDiskKV') &&
+              String(args[0]).startsWith('composerData:')
+            ) {
+              return { value: composerDataValue };
+            }
+            return undefined;
+          }),
+          all: vi.fn((..._args: unknown[]) => {
+            if (sql.includes('SELECT key, value FROM cursorDiskKV')) {
+              return [{ key: 'bubbleId:sid:b1', value: bubbleWithPaths }];
+            }
+            return [];
+          }),
+          run: mockRun,
+        })),
+        close: vi.fn(),
+      } as any;
+    } as any);
+
+    const result = await migrateSession('sid', {
+      destination: '/dest/project',
+      mode: 'move',
+      dryRun: false,
+    });
+
+    expect(result.success).toBe(true);
+    const composerUpdateCall = mockRun.mock.calls.find((call: unknown[]) => {
+      return String(call[1] || '') === 'composerData:sid';
+    });
+    expect(composerUpdateCall).toBeDefined();
+    const updatedComposer = JSON.parse(String(composerUpdateCall![0]));
+    expect(updatedComposer.workspaceUri).toBe('file:///dest/project');
   });
 });
 

--- a/tests/unit/migrate.test.ts
+++ b/tests/unit/migrate.test.ts
@@ -19,6 +19,8 @@ vi.mock('../../src/core/storage.js', () => ({
 
 // Mock platform functions
 vi.mock('../../src/lib/platform.js', () => ({
+  getGlobalStoragePath: (customDataPath?: string) =>
+    customDataPath ? customDataPath.replace(/\/[^/]+$/, '/globalStorage') : '/default/globalStorage',
   normalizePath: (p: string) => p.replace(/\/+$/, ''),
   pathsEqual: (a: string, b: string) => a === b,
 }));
@@ -632,6 +634,49 @@ describe('migrateWorkspace', () => {
 // Path transformation in global storage (copy mode)
 // =============================================================================
 describe('migrateSession - global storage path transformation (copy mode)', () => {
+  it('copy mode: uses the sibling globalStorage for a custom dataPath', async () => {
+    mockFindWorkspaceForSession.mockResolvedValue({
+      workspace: { id: 'ws1', path: '/source/project', dbPath: '/custom/workspaceStorage/ws1/state.vscdb', sessionCount: 1 },
+      dbPath: '/custom/workspaceStorage/ws1/state.vscdb',
+    });
+    mockFindWorkspaceByPath.mockResolvedValue({
+      workspace: { id: 'dest-ws', path: '/dest/project', dbPath: '/custom/workspaceStorage/ws2/state.vscdb', sessionCount: 0 },
+      dbPath: '/custom/workspaceStorage/ws2/state.vscdb',
+    });
+
+    mockOpenDatabaseReadWrite.mockResolvedValue(createMockDb());
+    mockGetComposerData
+      .mockReturnValueOnce({
+        composers: [{ composerId: 'sid', name: 'Session' }],
+        isNewFormat: true,
+        rawData: {},
+      })
+      .mockReturnValueOnce({ composers: [], isNewFormat: true, rawData: {} });
+
+    vi.mocked(existsSync).mockImplementation(
+      (p) => String(p) === '/custom/globalStorage/state.vscdb'
+    );
+
+    vi.mocked(BetterSqlite3).mockImplementation(function () {
+      return {
+        prepare: vi.fn(() => ({ get: vi.fn(), all: vi.fn(() => []), run: vi.fn() })),
+        close: vi.fn(),
+      } as any;
+    } as any);
+
+    const result = await migrateSession('sid', {
+      destination: '/dest/project',
+      mode: 'copy',
+      dryRun: false,
+      dataPath: '/custom/workspaceStorage',
+    });
+
+    expect(result.success).toBe(true);
+    const openedPaths = vi.mocked(BetterSqlite3).mock.calls.map((call) => String(call[0]));
+    expect(openedPaths.length).toBeGreaterThan(0);
+    expect(openedPaths.every((path) => path === '/custom/globalStorage/state.vscdb')).toBe(true);
+  });
+
   it('copy mode: transforms file paths in global storage', async () => {
     // Setup workspace mocks
     mockFindWorkspaceForSession.mockResolvedValue({

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -123,6 +123,22 @@ describe('parseChatData', () => {
     expect(result[0]!.messages[0]!.content).toBe('My Chat');
   });
 
+  it('parses composer sessions from root-level composer array', () => {
+    const data = [
+      {
+        composerId: 'c-array-1',
+        name: 'Array Chat',
+        createdAt: 1705300000000,
+        lastUpdatedAt: 1705303600000,
+      },
+    ];
+
+    const result = parseChatData(JSON.stringify(data));
+    expect(result).toHaveLength(1);
+    expect(result[0]!.id).toBe('c-array-1');
+    expect(result[0]!.title).toBe('Array Chat');
+  });
+
   it('uses (Empty session) for composer without name', () => {
     const data = {
       allComposers: [{ composerId: 'c2', createdAt: 1705300000000 }],

--- a/tests/unit/storage.test.ts
+++ b/tests/unit/storage.test.ts
@@ -1003,6 +1003,61 @@ describe('listSessions', () => {
     expect(result[0]!.workspacePath).toBe('/project/modern');
   });
 
+  it('recovers composerChatViewPane pointer sessions under a --workspace filter', async () => {
+    // #4: workspace filtering previously returned zero for modern (pointer-linked) data.
+    const guid = 'cccccccc-dddd-eeee-ffff-000000000000';
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const path = String(p);
+      return (
+        path.includes('state.vscdb') ||
+        path.includes('workspace.json') ||
+        path === '/data' ||
+        path.includes('globalStorage/state.vscdb')
+      );
+    });
+    vi.mocked(readdirSync).mockReturnValue([
+      { name: 'ws-modern', isDirectory: () => true } as unknown as ReturnType<typeof readdirSync>[0],
+    ]);
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ folder: '/project/modern' }));
+
+    const wsDb = createWorkspaceDbWithPointers(JSON.stringify({ selectedComposerIds: [] }), [
+      { key: `workbench.panel.composerChatViewPane.${guid}`, value: '{}' },
+    ]);
+    const globalDb = createGlobalDbForComposerMap({
+      [guid]: {
+        composerData: { name: 'Pointer Filtered', createdAt: 1778672423842, lastUpdatedAt: 1778682083842 },
+        bubbles: [{ type: 1, text: 'filtered pointer prompt' }],
+      },
+    });
+
+    mockOpenDatabase.mockImplementation(async (path: string) =>
+      String(path).includes('globalStorage') ? globalDb : wsDb
+    );
+
+    const result = await listSessions({ workspacePath: '/project/modern', all: true }, '/data');
+    expect(result).toHaveLength(1);
+    expect(result[0]!.id).toBe(guid);
+    expect(result[0]!.workspaceId).toBe('ws-modern');
+  });
+
+  it('scopes global recovery to the custom --data-path (no leak from default global storage)', async () => {
+    // Only the custom data dir exists; it has no workspaces and no sibling globalStorage.
+    vi.mocked(existsSync).mockImplementation((p) => String(p) === '/custom/workspaceStorage');
+    vi.mocked(readdirSync).mockReturnValue([]);
+
+    const result = await listSessions({ all: true }, '/custom/workspaceStorage');
+
+    expect(result).toHaveLength(0);
+    // Every global-storage probe must be the sibling of the custom path, never the
+    // machine's default global DB.
+    const globalChecks = vi
+      .mocked(existsSync)
+      .mock.calls.map((call) => String(call[0]))
+      .filter((path) => path.includes('globalStorage'));
+    expect(globalChecks.length).toBeGreaterThan(0);
+    expect(globalChecks.every((path) => path.includes('/custom/globalStorage'))).toBe(true);
+  });
+
   it('surfaces unattributed global composers via the catch-all under a global bucket', async () => {
     vi.mocked(existsSync).mockImplementation((p) => {
       const path = String(p);

--- a/tests/unit/storage.test.ts
+++ b/tests/unit/storage.test.ts
@@ -119,6 +119,19 @@ function createGlobalDbForComposerMap(
         return { get: vi.fn(() => ({ name: 'cursorDiskKV' })), all: vi.fn(() => []), run: vi.fn() };
       }
 
+      if (sql.includes("LIKE 'composerData:%'")) {
+        return {
+          get: vi.fn(),
+          all: vi.fn(() =>
+            Object.entries(composerMap).map(([composerId, entry]) => ({
+              key: `composerData:${composerId}`,
+              value: JSON.stringify(entry.composerData),
+            }))
+          ),
+          run: vi.fn(),
+        };
+      }
+
       if (sql.includes('SELECT value FROM cursorDiskKV WHERE key = ?')) {
         return {
           get: vi.fn((key?: string) => {
@@ -599,6 +612,102 @@ describe('listSessions', () => {
     expect(result[0]!.title).toBe('Legacy Session');
   });
 
+  it('unions selectedComposerIds recovery with stale legacy chat data', async () => {
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const path = String(p);
+      return (
+        path.includes('state.vscdb') ||
+        path.includes('workspace.json') ||
+        path === '/data' ||
+        path.includes('globalStorage/state.vscdb')
+      );
+    });
+    vi.mocked(readdirSync).mockReturnValue([
+      { name: 'ws1', isDirectory: () => true } as unknown as ReturnType<typeof readdirSync>[0],
+    ]);
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ folder: '/project/new' }));
+
+    const workspaceComposerData = JSON.stringify({
+      selectedComposerIds: ['recent-1'],
+      hasMigratedComposerData: false,
+    });
+    const staleLegacyData = JSON.stringify({
+      chatSessions: [
+        {
+          id: 'legacy-session-1',
+          title: 'Legacy Session',
+          createdAt: 1705300000000,
+          messages: [{ role: 'user', content: 'legacy content' }],
+        },
+      ],
+    });
+    const wsDb = createWorkspaceDbWithKeyValues({
+      'composer.composerData': workspaceComposerData,
+      'workbench.panel.aichat.view.aichat.chatdata': staleLegacyData,
+    });
+    const globalDb = createGlobalDbForComposerMap({
+      'recent-1': {
+        composerData: {
+          name: 'Recent Recovered Session',
+          createdAt: 1778672423842,
+          lastUpdatedAt: 1778682083842,
+        },
+        bubbles: [{ type: 1, text: 'recent prompt' }],
+      },
+    });
+
+    mockOpenDatabase.mockImplementation(async (path: string) =>
+      String(path).includes('globalStorage') ? globalDb : wsDb
+    );
+
+    const result = await listSessions({ limit: 10, all: false }, '/data');
+    expect(result.map((session) => session.id)).toEqual(
+      expect.arrayContaining(['legacy-session-1', 'recent-1'])
+    );
+  });
+
+  it('unions selectedComposerIds recovery with non-empty allComposers', async () => {
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const path = String(p);
+      return (
+        path.includes('state.vscdb') ||
+        path.includes('workspace.json') ||
+        path === '/data' ||
+        path.includes('globalStorage/state.vscdb')
+      );
+    });
+    vi.mocked(readdirSync).mockReturnValue([
+      { name: 'ws1', isDirectory: () => true } as unknown as ReturnType<typeof readdirSync>[0],
+    ]);
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ folder: '/project/new' }));
+
+    const workspaceComposerData = JSON.stringify({
+      allComposers: [{ composerId: 'old-1', name: 'Old Visible Session', createdAt: 1705300000000 }],
+      selectedComposerIds: ['recent-1'],
+      hasMigratedComposerData: true,
+    });
+    const wsDb = createWorkspaceDb(workspaceComposerData);
+    const globalDb = createGlobalDbForComposerMap({
+      'recent-1': {
+        composerData: {
+          name: 'Recent Recovered Session',
+          createdAt: 1778672423842,
+          lastUpdatedAt: 1778682083842,
+        },
+        bubbles: [{ type: 1, text: 'recent prompt' }],
+      },
+    });
+
+    mockOpenDatabase.mockImplementation(async (path: string) =>
+      String(path).includes('globalStorage') ? globalDb : wsDb
+    );
+
+    const result = await listSessions({ limit: 10, all: false }, '/data');
+    expect(result.map((session) => session.id)).toEqual(
+      expect.arrayContaining(['old-1', 'recent-1'])
+    );
+  });
+
   it('resolves selectedComposerIds via global storage when workspace composer list is unavailable', async () => {
     vi.mocked(existsSync).mockImplementation((p) => {
       const path = String(p);
@@ -639,6 +748,59 @@ describe('listSessions', () => {
     expect(result[0]!.id).toBe('sel-global-1');
     expect(result[0]!.title).toBe('Recovered Session');
     expect(result[0]!.workspacePath).toBe('/project/new');
+  });
+
+  it('recovers global composers linked by modern workspaceIdentifier', async () => {
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const path = String(p);
+      return (
+        path.includes('state.vscdb') ||
+        path.includes('workspace.json') ||
+        path === '/data' ||
+        path.includes('globalStorage/state.vscdb')
+      );
+    });
+    vi.mocked(readdirSync).mockReturnValue([
+      { name: 'ws-modern', isDirectory: () => true } as unknown as ReturnType<
+        typeof readdirSync
+      >[0],
+    ]);
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ folder: '/project/new' }));
+
+    const wsDb = createWorkspaceDb(
+      JSON.stringify({
+        selectedComposerIds: [],
+        hasMigratedComposerData: false,
+      })
+    );
+    const globalDb = createGlobalDbForComposerMap({
+      'workspace-linked-1': {
+        composerData: {
+          name: 'Workspace Linked Session',
+          createdAt: 1778672423842,
+          lastUpdatedAt: 1778682083842,
+          workspaceIdentifier: {
+            id: 'ws-modern',
+            uri: {
+              fsPath: '/project/new',
+              external: 'file:///project/new',
+              path: '/project/new',
+              scheme: 'file',
+            },
+          },
+        },
+        bubbles: [{ type: 1, text: 'workspace linked prompt' }],
+      },
+    });
+
+    mockOpenDatabase.mockImplementation(async (path: string) =>
+      String(path).includes('globalStorage') ? globalDb : wsDb
+    );
+
+    const result = await listSessions({ limit: 10, all: false }, '/data');
+    expect(result).toHaveLength(1);
+    expect(result[0]!.id).toBe('workspace-linked-1');
+    expect(result[0]!.lastUpdatedAt.toISOString()).toBe('2026-05-13T14:21:23.842Z');
   });
 
   it('skips selectedComposerIds fallback entries that have no global bubbles', async () => {
@@ -1400,6 +1562,20 @@ describe('getComposerData', () => {
     expect(result!.composers.map((c) => c.composerId)).toEqual(['sel-a', 'sel-b']);
   });
 
+  it('unions selectedComposerIds that are missing from non-empty allComposers', () => {
+    const data = JSON.stringify({
+      allComposers: [{ composerId: 'old-1', name: 'Old Session' }],
+      selectedComposerIds: ['old-1', 'recent-1'],
+      hasMigratedComposerData: true,
+    });
+    const db = createMockDb({ ItemTable: { get: { value: data } } });
+    const result = getComposerData(db);
+    expect(result).not.toBeNull();
+    expect(result!.isNewFormat).toBe(true);
+    expect(result!.composers.map((c) => c.composerId)).toEqual(['old-1', 'recent-1']);
+    expect(result!.composers[0]!.name).toBe('Old Session');
+  });
+
   it('returns null when no data', () => {
     const db = createMockDb({});
     const result = getComposerData(db);
@@ -1439,7 +1615,7 @@ describe('updateComposerData', () => {
     const writtenJson = mockRun.mock.calls[0]![0] as string;
     const parsed = JSON.parse(writtenJson);
     expect(parsed.allComposers).toEqual(composers);
-    expect(parsed.selectedComposerIds).toEqual(['x']); // Preserved
+    expect(parsed.selectedComposerIds).toEqual(['c1']);
   });
 
   it('writes legacy format as direct array', () => {
@@ -1481,6 +1657,31 @@ describe('updateComposerData', () => {
     expect(parsed.allComposers).toEqual(composers);
     expect(parsed.selectedComposerIds).toEqual(['new-1', 'new-2']);
     expect(parsed.lastFocusedComposerIds).toEqual(['new-1']);
+  });
+
+  it('filters selectedComposerIds for mixed allComposers format', () => {
+    const mockRun = vi.fn();
+    const db: Database = {
+      prepare: vi.fn(() => ({ get: vi.fn(), all: vi.fn(() => []), run: mockRun })),
+      close: vi.fn(),
+      runSQL: vi.fn(),
+    };
+
+    const composers = [{ composerId: 'remaining-1' }];
+    const originalRaw = {
+      allComposers: [{ composerId: 'remaining-1' }, { composerId: 'moved-1' }],
+      selectedComposerIds: ['remaining-1', 'moved-1'],
+      lastFocusedComposerIds: ['moved-1'],
+      hasMigratedComposerData: true,
+    };
+
+    updateComposerData(db, composers, true, originalRaw);
+
+    const writtenJson = mockRun.mock.calls[0]![0] as string;
+    const parsed = JSON.parse(writtenJson);
+    expect(parsed.allComposers).toEqual(composers);
+    expect(parsed.selectedComposerIds).toEqual(['remaining-1']);
+    expect(parsed.lastFocusedComposerIds).toEqual([]);
   });
 });
 
@@ -1836,7 +2037,16 @@ describe('listGlobalSessions (with data)', () => {
 
     const composerValue = JSON.stringify({
       name: 'Global Session',
-      createdAt: '2024-01-15T10:00:00Z',
+      createdAt: 1705312800000,
+      lastUpdatedAt: 1705313100000,
+      workspaceIdentifier: {
+        uri: {
+          fsPath: '/project/global',
+          external: 'file:///project/global',
+          path: '/project/global',
+          scheme: 'file',
+        },
+      },
     });
     const bubbleValue = JSON.stringify({ type: 1, text: 'Hello from global' });
 
@@ -1872,6 +2082,9 @@ describe('listGlobalSessions (with data)', () => {
     expect(result.length).toBeGreaterThanOrEqual(1);
     expect(result[0]!.title).toBe('Global Session');
     expect(result[0]!.messageCount).toBe(2);
+    expect(result[0]!.createdAt.toISOString()).toBe('2024-01-15T10:00:00.000Z');
+    expect(result[0]!.lastUpdatedAt.toISOString()).toBe('2024-01-15T10:05:00.000Z');
+    expect(result[0]!.workspacePath).toBe('/project/global');
   });
 });
 

--- a/tests/unit/storage.test.ts
+++ b/tests/unit/storage.test.ts
@@ -803,6 +803,64 @@ describe('listSessions', () => {
     expect(result[0]!.lastUpdatedAt.toISOString()).toBe('2026-05-13T14:21:23.842Z');
   });
 
+  it('lists a workspace-linked global session once under --workspace when two dirs share a path', async () => {
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const path = String(p);
+      return (
+        path.includes('state.vscdb') ||
+        path.includes('workspace.json') ||
+        path === '/data' ||
+        path.includes('globalStorage/state.vscdb')
+      );
+    });
+    // Two workspaceStorage dirs that both resolve to the same project path.
+    vi.mocked(readdirSync).mockReturnValue([
+      { name: 'ws-a', isDirectory: () => true } as unknown as ReturnType<typeof readdirSync>[0],
+      { name: 'ws-b', isDirectory: () => true } as unknown as ReturnType<typeof readdirSync>[0],
+    ]);
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ folder: '/project/dup' }));
+
+    const wsDbA = createWorkspaceDb(JSON.stringify({ selectedComposerIds: ['a-own'] }));
+    const wsDbB = createWorkspaceDb(JSON.stringify({ selectedComposerIds: ['b-own'] }));
+    const globalDb = createGlobalDbForComposerMap({
+      // Own sessions are linked only by selectedComposerIds (no workspace metadata).
+      'a-own': {
+        composerData: { name: 'A Own', createdAt: 1778672423842, lastUpdatedAt: 1778672423842 },
+        bubbles: [{ type: 1, text: 'a own' }],
+      },
+      'b-own': {
+        composerData: { name: 'B Own', createdAt: 1778672423842, lastUpdatedAt: 1778672423842 },
+        bubbles: [{ type: 1, text: 'b own' }],
+      },
+      // Shared session is workspace-linked to the path that BOTH dirs resolve to.
+      shared: {
+        composerData: {
+          name: 'Shared Linked',
+          createdAt: 1778672423842,
+          lastUpdatedAt: 1778672423842,
+          workspaceIdentifier: {
+            uri: { fsPath: '/project/dup', external: 'file:///project/dup', path: '/project/dup' },
+          },
+        },
+        bubbles: [{ type: 1, text: 'shared' }],
+      },
+    });
+
+    mockOpenDatabase.mockImplementation(async (path: string) => {
+      if (String(path).includes('globalStorage')) return globalDb;
+      return String(path).includes('ws-a') ? wsDbA : wsDbB;
+    });
+
+    const result = await listSessions(
+      { limit: 50, all: true, workspacePath: '/project/dup' },
+      '/data'
+    );
+
+    const ids = result.map((s) => s.id);
+    expect(ids).toEqual(expect.arrayContaining(['a-own', 'b-own', 'shared']));
+    expect(ids.filter((id) => id === 'shared')).toHaveLength(1);
+  });
+
   it('skips selectedComposerIds fallback entries that have no global bubbles', async () => {
     vi.mocked(existsSync).mockImplementation((p) => {
       const path = String(p);
@@ -1607,7 +1665,7 @@ describe('updateComposerData', () => {
       runSQL: vi.fn(),
     };
 
-    const composers = [{ composerId: 'c1' }];
+    const composers = [{ composerId: 'c1', name: 'C1' }];
     const originalRaw = { allComposers: [], selectedComposerIds: ['x'] };
     updateComposerData(db, composers, true, originalRaw);
 
@@ -1616,6 +1674,25 @@ describe('updateComposerData', () => {
     const parsed = JSON.parse(writtenJson);
     expect(parsed.allComposers).toEqual(composers);
     expect(parsed.selectedComposerIds).toEqual(['c1']);
+  });
+
+  it('does not persist id-only composer stubs into allComposers', () => {
+    const mockRun = vi.fn();
+    const db: Database = {
+      prepare: vi.fn(() => ({ get: vi.fn(), all: vi.fn(() => []), run: mockRun })),
+      close: vi.fn(),
+      runSQL: vi.fn(),
+    };
+
+    // Synthetic stubs (only composerId) come from getComposerData's selectedComposerIds
+    // union; persisting them would create phantom sessions on the next list.
+    const composers = [{ composerId: 'stub-1' }];
+    const originalRaw = { allComposers: [], selectedComposerIds: ['old-1'] };
+    updateComposerData(db, composers, true, originalRaw);
+
+    const parsed = JSON.parse(mockRun.mock.calls[0]![0] as string);
+    expect(parsed.allComposers).toEqual([]);
+    expect(parsed.selectedComposerIds).toEqual(['stub-1']);
   });
 
   it('writes legacy format as direct array', () => {
@@ -1654,7 +1731,8 @@ describe('updateComposerData', () => {
 
     const writtenJson = mockRun.mock.calls[0]![0] as string;
     const parsed = JSON.parse(writtenJson);
-    expect(parsed.allComposers).toEqual(composers);
+    // Stubs stay out of allComposers; their IDs are reflected in selectedComposerIds.
+    expect(parsed.allComposers).toEqual([]);
     expect(parsed.selectedComposerIds).toEqual(['new-1', 'new-2']);
     expect(parsed.lastFocusedComposerIds).toEqual(['new-1']);
   });
@@ -1667,9 +1745,12 @@ describe('updateComposerData', () => {
       runSQL: vi.fn(),
     };
 
-    const composers = [{ composerId: 'remaining-1' }];
+    const composers = [{ composerId: 'remaining-1', name: 'Remaining' }];
     const originalRaw = {
-      allComposers: [{ composerId: 'remaining-1' }, { composerId: 'moved-1' }],
+      allComposers: [
+        { composerId: 'remaining-1', name: 'Remaining' },
+        { composerId: 'moved-1', name: 'Moved' },
+      ],
       selectedComposerIds: ['remaining-1', 'moved-1'],
       lastFocusedComposerIds: ['moved-1'],
       hasMigratedComposerData: true,
@@ -1679,9 +1760,32 @@ describe('updateComposerData', () => {
 
     const writtenJson = mockRun.mock.calls[0]![0] as string;
     const parsed = JSON.parse(writtenJson);
-    expect(parsed.allComposers).toEqual(composers);
+    expect(parsed.allComposers).toEqual([{ composerId: 'remaining-1', name: 'Remaining' }]);
     expect(parsed.selectedComposerIds).toEqual(['remaining-1']);
     expect(parsed.lastFocusedComposerIds).toEqual([]);
+  });
+
+  it('preserves the focused tab when it survives the update', () => {
+    const mockRun = vi.fn();
+    const db: Database = {
+      prepare: vi.fn(() => ({ get: vi.fn(), all: vi.fn(() => []), run: mockRun })),
+      close: vi.fn(),
+      runSQL: vi.fn(),
+    };
+
+    // Migrating a non-focused composer ('a') must not demote the still-present
+    // focused composer ('c') to the first surviving id.
+    const composers = [{ composerId: 'b' }, { composerId: 'c' }];
+    const originalRaw = {
+      selectedComposerIds: ['a', 'b', 'c'],
+      lastFocusedComposerIds: ['c'],
+    };
+
+    updateComposerData(db, composers, true, originalRaw);
+
+    const parsed = JSON.parse(mockRun.mock.calls[0]![0] as string);
+    expect(parsed.selectedComposerIds).toEqual(['b', 'c']);
+    expect(parsed.lastFocusedComposerIds).toEqual(['c']);
   });
 });
 

--- a/tests/unit/storage.test.ts
+++ b/tests/unit/storage.test.ts
@@ -88,6 +88,83 @@ function createWorkspaceDb(composerValue: string): Database {
   };
 }
 
+function createWorkspaceDbWithKeyValues(keyValues: Record<string, string>): Database {
+  return {
+    prepare: vi.fn(() => ({
+      get: vi.fn((key?: string) => {
+        if (!key) return undefined;
+        const value = keyValues[key];
+        return value ? { value } : undefined;
+      }),
+      all: vi.fn(() => []),
+      run: vi.fn(),
+    })),
+    close: vi.fn(),
+    runSQL: vi.fn(),
+  };
+}
+
+function createGlobalDbForComposerMap(
+  composerMap: Record<
+    string,
+    {
+      composerData: Record<string, unknown>;
+      bubbles: Array<Record<string, unknown>>;
+    }
+  >
+): Database {
+  return {
+    prepare: vi.fn((sql: string) => {
+      if (sql.includes('sqlite_master')) {
+        return { get: vi.fn(() => ({ name: 'cursorDiskKV' })), all: vi.fn(() => []), run: vi.fn() };
+      }
+
+      if (sql.includes('SELECT value FROM cursorDiskKV WHERE key = ?')) {
+        return {
+          get: vi.fn((key?: string) => {
+            if (!key || !String(key).startsWith('composerData:')) return undefined;
+            const composerId = String(key).replace('composerData:', '');
+            const entry = composerMap[composerId];
+            return entry ? { value: JSON.stringify(entry.composerData) } : undefined;
+          }),
+          all: vi.fn(() => []),
+          run: vi.fn(),
+        };
+      }
+
+      if (sql.includes('COUNT(*) as count') && sql.includes('cursorDiskKV')) {
+        return {
+          get: vi.fn((pattern?: string) => {
+            const match = String(pattern).match(/^bubbleId:(.+):%$/);
+            const composerId = match?.[1];
+            const bubbles = composerId ? composerMap[composerId]?.bubbles ?? [] : [];
+            return { count: bubbles.length };
+          }),
+          all: vi.fn(() => []),
+          run: vi.fn(),
+        };
+      }
+
+      if (sql.includes('ORDER BY rowid ASC LIMIT 1') && sql.includes('cursorDiskKV')) {
+        return {
+          get: vi.fn((pattern?: string) => {
+            const match = String(pattern).match(/^bubbleId:(.+):%$/);
+            const composerId = match?.[1];
+            const firstBubble = composerId ? composerMap[composerId]?.bubbles?.[0] : undefined;
+            return firstBubble ? { value: JSON.stringify(firstBubble) } : undefined;
+          }),
+          all: vi.fn(() => []),
+          run: vi.fn(),
+        };
+      }
+
+      return { get: vi.fn(), all: vi.fn(() => []), run: vi.fn() };
+    }),
+    close: vi.fn(),
+    runSQL: vi.fn(),
+  };
+}
+
 /**
  * Create a global storage mock DB with cursorDiskKV table and bubble data.
  */
@@ -323,6 +400,48 @@ describe('findWorkspaces', () => {
     expect(result[0]!.path).toBe('/path/to/ws.code-workspace');
     expect(result[0]!.sessionCount).toBe(1);
   });
+
+  it('falls back to workspace ID path when workspace.json is missing folder/workspace keys', async () => {
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const path = String(p);
+      return path.includes('state.vscdb') || path.includes('workspace.json') || path === '/data';
+    });
+    vi.mocked(readdirSync).mockReturnValue([
+      { name: 'ws-fallback', isDirectory: () => true } as unknown as ReturnType<typeof readdirSync>[0],
+    ]);
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ someNewShape: 'value' }));
+
+    const composerData = JSON.stringify({
+      allComposers: [{ composerId: 'c-fallback', name: 'Fallback Session' }],
+    });
+    mockOpenDatabase.mockResolvedValue(createWorkspaceDb(composerData));
+
+    const result = await findWorkspaces('/data');
+    expect(result).toHaveLength(1);
+    expect(result[0]!.path).toBe('(workspace: ws-fallback)');
+    expect(result[0]!.sessionCount).toBe(1);
+  });
+
+  it('counts selectedComposerIds when composer list is not present', async () => {
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const path = String(p);
+      return path.includes('state.vscdb') || path.includes('workspace.json') || path === '/data';
+    });
+    vi.mocked(readdirSync).mockReturnValue([
+      { name: 'ws-selected', isDirectory: () => true } as unknown as ReturnType<typeof readdirSync>[0],
+    ]);
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ folder: '/project/new' }));
+
+    const selectedOnly = JSON.stringify({
+      selectedComposerIds: ['sel-1', 'sel-2'],
+      hasMigratedComposerData: false,
+    });
+    mockOpenDatabase.mockResolvedValue(createWorkspaceDb(selectedOnly));
+
+    const result = await findWorkspaces('/data');
+    expect(result).toHaveLength(1);
+    expect(result[0]!.sessionCount).toBe(2);
+  });
 });
 
 // =============================================================================
@@ -443,6 +562,164 @@ describe('listSessions', () => {
 
     const result = await listSessions({ limit: 1, all: true }, '/data');
     expect(result).toHaveLength(3);
+  });
+
+  it('falls back to legacy chat key when composer key parses to zero sessions', async () => {
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const path = String(p);
+      return path.includes('state.vscdb') || path.includes('workspace.json') || path === '/data';
+    });
+    vi.mocked(readdirSync).mockReturnValue([
+      { name: 'ws1', isDirectory: () => true } as unknown as ReturnType<typeof readdirSync>[0],
+    ]);
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ folder: '/project' }));
+
+    const staleComposerData = JSON.stringify({});
+    const legacyData = JSON.stringify({
+      chatSessions: [
+        {
+          id: 'legacy-session-1',
+          title: 'Legacy Session',
+          createdAt: 1705300000000,
+          messages: [{ role: 'user', content: 'legacy content' }],
+        },
+      ],
+    });
+
+    mockOpenDatabase.mockResolvedValue(
+      createWorkspaceDbWithKeyValues({
+        'composer.composerData': staleComposerData,
+        'workbench.panel.aichat.view.aichat.chatdata': legacyData,
+      })
+    );
+
+    const result = await listSessions({ limit: 10, all: false }, '/data');
+    expect(result).toHaveLength(1);
+    expect(result[0]!.id).toBe('legacy-session-1');
+    expect(result[0]!.title).toBe('Legacy Session');
+  });
+
+  it('resolves selectedComposerIds via global storage when workspace composer list is unavailable', async () => {
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const path = String(p);
+      return (
+        path.includes('state.vscdb') ||
+        path.includes('workspace.json') ||
+        path === '/data' ||
+        path.includes('globalStorage/state.vscdb')
+      );
+    });
+    vi.mocked(readdirSync).mockReturnValue([
+      { name: 'ws1', isDirectory: () => true } as unknown as ReturnType<typeof readdirSync>[0],
+    ]);
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ folder: '/project/new' }));
+
+    const workspaceComposerData = JSON.stringify({
+      selectedComposerIds: ['sel-global-1'],
+      hasMigratedComposerData: false,
+    });
+    const wsDb = createWorkspaceDb(workspaceComposerData);
+    const globalDb = createGlobalDbForComposerMap({
+      'sel-global-1': {
+        composerData: {
+          name: 'Recovered Session',
+          createdAt: '2026-05-13T14:20:23.842Z',
+          updatedAt: '2026-05-13T14:21:23.842Z',
+        },
+        bubbles: [{ type: 1, text: 'recent prompt' }],
+      },
+    });
+
+    mockOpenDatabase.mockImplementation(async (path: string) =>
+      String(path).includes('globalStorage') ? globalDb : wsDb
+    );
+
+    const result = await listSessions({ limit: 10, all: false }, '/data');
+    expect(result).toHaveLength(1);
+    expect(result[0]!.id).toBe('sel-global-1');
+    expect(result[0]!.title).toBe('Recovered Session');
+    expect(result[0]!.workspacePath).toBe('/project/new');
+  });
+
+  it('skips selectedComposerIds fallback entries that have no global bubbles', async () => {
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const path = String(p);
+      return (
+        path.includes('state.vscdb') ||
+        path.includes('workspace.json') ||
+        path === '/data' ||
+        path.includes('globalStorage/state.vscdb')
+      );
+    });
+    vi.mocked(readdirSync).mockReturnValue([
+      { name: 'ws1', isDirectory: () => true } as unknown as ReturnType<typeof readdirSync>[0],
+    ]);
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ folder: '/project/new' }));
+
+    const workspaceComposerData = JSON.stringify({
+      allComposers: [],
+      selectedComposerIds: ['stale-1'],
+      hasMigratedComposerData: true,
+    });
+    const wsDb = createWorkspaceDb(workspaceComposerData);
+    const globalDb = createGlobalDbForComposerMap({
+      'stale-1': {
+        composerData: {
+          name: 'Should Not Be Listed',
+          createdAt: '2026-05-13T14:20:23.842Z',
+          updatedAt: '2026-05-13T14:21:23.842Z',
+        },
+        bubbles: [],
+      },
+    });
+
+    mockOpenDatabase.mockImplementation(async (path: string) =>
+      String(path).includes('globalStorage') ? globalDb : wsDb
+    );
+
+    const result = await listSessions({ limit: 10, all: false }, '/data');
+    expect(result).toHaveLength(0);
+  });
+
+  it('uses selectedComposerIds fallback when allComposers is empty but global bubbles exist', async () => {
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const path = String(p);
+      return (
+        path.includes('state.vscdb') ||
+        path.includes('workspace.json') ||
+        path === '/data' ||
+        path.includes('globalStorage/state.vscdb')
+      );
+    });
+    vi.mocked(readdirSync).mockReturnValue([
+      { name: 'ws1', isDirectory: () => true } as unknown as ReturnType<typeof readdirSync>[0],
+    ]);
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ folder: '/project/new' }));
+
+    const workspaceComposerData = JSON.stringify({
+      allComposers: [],
+      selectedComposerIds: ['valid-1'],
+      hasMigratedComposerData: true,
+    });
+    const wsDb = createWorkspaceDb(workspaceComposerData);
+    const globalDb = createGlobalDbForComposerMap({
+      'valid-1': {
+        composerData: {
+          name: 'Recovered From Selected',
+          createdAt: '2026-05-13T14:20:23.842Z',
+          updatedAt: '2026-05-13T14:21:23.842Z',
+        },
+        bubbles: [{ type: 1, text: 'session content' }],
+      },
+    });
+
+    mockOpenDatabase.mockImplementation(async (path: string) =>
+      String(path).includes('globalStorage') ? globalDb : wsDb
+    );
+
+    const result = await listSessions({ limit: 10, all: false }, '/data');
+    expect(result).toHaveLength(1);
+    expect(result[0]!.id).toBe('valid-1');
   });
 
   it('deduplicates by session id when same session appears in multiple workspaces and attributes to first in sort order', async () => {
@@ -1098,6 +1375,31 @@ describe('getComposerData', () => {
     expect(result!.composers).toHaveLength(1);
   });
 
+  it('returns selectedComposerIds-only format as composer refs', () => {
+    const data = JSON.stringify({
+      selectedComposerIds: ['sel-1', 'sel-2'],
+      hasMigratedComposerData: false,
+    });
+    const db = createMockDb({ ItemTable: { get: { value: data } } });
+    const result = getComposerData(db);
+    expect(result).not.toBeNull();
+    expect(result!.isNewFormat).toBe(true);
+    expect(result!.composers.map((c) => c.composerId)).toEqual(['sel-1', 'sel-2']);
+  });
+
+  it('falls back to selectedComposerIds when allComposers exists but is empty', () => {
+    const data = JSON.stringify({
+      allComposers: [],
+      selectedComposerIds: ['sel-a', 'sel-b'],
+      hasMigratedComposerData: true,
+    });
+    const db = createMockDb({ ItemTable: { get: { value: data } } });
+    const result = getComposerData(db);
+    expect(result).not.toBeNull();
+    expect(result!.isNewFormat).toBe(true);
+    expect(result!.composers.map((c) => c.composerId)).toEqual(['sel-a', 'sel-b']);
+  });
+
   it('returns null when no data', () => {
     const db = createMockDb({});
     const result = getComposerData(db);
@@ -1155,6 +1457,30 @@ describe('updateComposerData', () => {
     const parsed = JSON.parse(writtenJson);
     expect(Array.isArray(parsed)).toBe(true);
     expect(parsed).toEqual(composers);
+  });
+
+  it('updates selected-only format selectedComposerIds consistently', () => {
+    const mockRun = vi.fn();
+    const db: Database = {
+      prepare: vi.fn(() => ({ get: vi.fn(), all: vi.fn(() => []), run: mockRun })),
+      close: vi.fn(),
+      runSQL: vi.fn(),
+    };
+
+    const composers = [{ composerId: 'new-1' }, { composerId: 'new-2' }];
+    const originalRaw = {
+      selectedComposerIds: ['old-1'],
+      lastFocusedComposerIds: ['old-1'],
+      hasMigratedComposerData: false,
+    };
+
+    updateComposerData(db, composers, true, originalRaw);
+
+    const writtenJson = mockRun.mock.calls[0]![0] as string;
+    const parsed = JSON.parse(writtenJson);
+    expect(parsed.allComposers).toEqual(composers);
+    expect(parsed.selectedComposerIds).toEqual(['new-1', 'new-2']);
+    expect(parsed.lastFocusedComposerIds).toEqual(['new-1']);
   });
 });
 
@@ -1258,6 +1584,25 @@ describe('findWorkspaceByPath', () => {
     expect(result).not.toBeNull();
     expect(result!.workspace.path).toBe('/path/to/ws.code-workspace');
     expect(result!.dbPath).toContain('state.vscdb');
+  });
+
+  it('finds workspace by path even when workspace has zero sessions', async () => {
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const path = String(p);
+      return path.includes('state.vscdb') || path.includes('workspace.json') || path === '/data';
+    });
+    vi.mocked(readdirSync).mockReturnValue([
+      { name: 'ws-empty', isDirectory: () => true } as unknown as ReturnType<typeof readdirSync>[0],
+    ]);
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ folder: '/empty/project' }));
+
+    // No chat keys in DB, so findWorkspaces() will exclude it and fallback path lookup must find it.
+    mockOpenDatabase.mockResolvedValue(createWorkspaceDbWithKeyValues({}));
+
+    const result = await findWorkspaceByPath('/empty/project', '/data');
+    expect(result).not.toBeNull();
+    expect(result!.workspace.path).toBe('/empty/project');
+    expect(result!.workspace.sessionCount).toBe(0);
   });
 });
 
@@ -1437,6 +1782,24 @@ describe('findWorkspaceForSession (with match)', () => {
     mockOpenDatabase.mockResolvedValue(createWorkspaceDb(composerData));
 
     const result = await findWorkspaceForSession('target-id', '/data');
+    expect(result).not.toBeNull();
+    expect(result!.workspace.path).toBe('/project');
+  });
+
+  it('matches session in selectedComposerIds-only workspace data', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readdirSync).mockReturnValue([
+      { name: 'ws1', isDirectory: () => true } as unknown as ReturnType<typeof readdirSync>[0],
+    ]);
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ folder: '/project' }));
+
+    const selectedOnlyData = JSON.stringify({
+      selectedComposerIds: ['selected-target'],
+      hasMigratedComposerData: false,
+    });
+    mockOpenDatabase.mockResolvedValue(createWorkspaceDb(selectedOnlyData));
+
+    const result = await findWorkspaceForSession('selected-target', '/data');
     expect(result).not.toBeNull();
     expect(result!.workspace.path).toBe('/project');
   });

--- a/tests/unit/storage.test.ts
+++ b/tests/unit/storage.test.ts
@@ -1444,6 +1444,61 @@ describe('getSession', () => {
     expect(result!.messages[1]!.content).toBe('Here is my response');
   });
 
+  it('loads global bubbles from the sibling globalStorage for a custom dataPath', async () => {
+    const customDataPath = '/custom/workspaceStorage';
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const path = String(p);
+      return (
+        path === customDataPath ||
+        path === '/custom/globalStorage/state.vscdb' ||
+        path.includes('/custom/workspaceStorage/ws1/state.vscdb') ||
+        path.includes('/custom/workspaceStorage/ws1/workspace.json')
+      );
+    });
+    vi.mocked(readdirSync).mockReturnValue([
+      { name: 'ws1', isDirectory: () => true } as unknown as ReturnType<typeof readdirSync>[0],
+    ]);
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ folder: '/custom/project' }));
+
+    const wsDb = createWorkspaceDb(
+      JSON.stringify({
+        allComposers: [{ composerId: 'custom-1', name: 'Custom Session', createdAt: 1000 }],
+      })
+    );
+    const globalDb = createGlobalDb(
+      [
+        {
+          key: 'bubbleId:custom-1:b1',
+          value: JSON.stringify({
+            type: 1,
+            text: 'custom profile message',
+            createdAt: '2024-01-15T10:00:00Z',
+            bubbleId: 'b1',
+          }),
+        },
+      ],
+      JSON.stringify({ name: 'Custom Session', createdAt: 1000, lastUpdatedAt: 2000 })
+    );
+
+    mockOpenDatabase.mockImplementation(async (path: string) => {
+      if (path === '/custom/globalStorage/state.vscdb') return globalDb;
+      if (path.includes('globalStorage')) {
+        throw new Error(`wrong global path: ${path}`);
+      }
+      return wsDb;
+    });
+
+    const result = await getSession('custom-1', customDataPath);
+
+    expect(result).not.toBeNull();
+    expect(result!.source).toBe('global');
+    expect(result!.messages).toHaveLength(1);
+    expect(result!.messages[0]!.content).toBe('custom profile message');
+    const openedPaths = mockOpenDatabase.mock.calls.map((call) => String(call[0]));
+    expect(openedPaths).toContain('/custom/globalStorage/state.vscdb');
+    expect(openedPaths.some((path) => path.includes('Application Support/Cursor'))).toBe(false);
+  });
+
   it('returns same session when called with composer ID string', async () => {
     vi.mocked(existsSync).mockReturnValue(true);
     vi.mocked(readdirSync).mockReturnValue([

--- a/tests/unit/storage.test.ts
+++ b/tests/unit/storage.test.ts
@@ -56,6 +56,7 @@ import {
   resolveSessionIdentifiers,
   findWorkspaceForSession,
   findWorkspaceByPath,
+  getWorkspaceLinkedComposerIds,
   listWorkspaces,
   listGlobalSessions,
   getGlobalSession,
@@ -104,6 +105,23 @@ function createWorkspaceDbWithKeyValues(keyValues: Record<string, string>): Data
   };
 }
 
+function createWorkspaceDbWithPointers(
+  composerValue: string,
+  pointerRows: Array<{ key: string; value: string }>
+): Database {
+  return {
+    prepare: vi.fn((sql: string) => ({
+      get: vi.fn((key?: string) =>
+        key === 'composer.composerData' ? { value: composerValue } : undefined
+      ),
+      all: vi.fn(() => (sql.includes('composerChatViewPane') ? pointerRows : [])),
+      run: vi.fn(),
+    })),
+    close: vi.fn(),
+    runSQL: vi.fn(),
+  };
+}
+
 function createGlobalDbForComposerMap(
   composerMap: Record<
     string,
@@ -127,6 +145,19 @@ function createGlobalDbForComposerMap(
               key: `composerData:${composerId}`,
               value: JSON.stringify(entry.composerData),
             }))
+          ),
+          run: vi.fn(),
+        };
+      }
+
+      // One-pass bubble key listing used by loadGlobalBubbleCounts.
+      if (sql.includes("LIKE 'bubbleId:%'")) {
+        return {
+          get: vi.fn(),
+          all: vi.fn(() =>
+            Object.entries(composerMap).flatMap(([composerId, entry]) =>
+              entry.bubbles.map((_, i) => ({ key: `bubbleId:${composerId}:${i}` }))
+            )
           ),
           run: vi.fn(),
         };
@@ -454,6 +485,78 @@ describe('findWorkspaces', () => {
     const result = await findWorkspaces('/data');
     expect(result).toHaveLength(1);
     expect(result[0]!.sessionCount).toBe(2);
+  });
+
+  it('does not count composerChatViewPane pointer GUIDs when global storage is unavailable', async () => {
+    // No globalStorage in existsSync -> global DB unavailable.
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const path = String(p);
+      return path.includes('state.vscdb') || path.includes('workspace.json') || path === '/data';
+    });
+    vi.mocked(readdirSync).mockReturnValue([
+      { name: 'ws-modern', isDirectory: () => true } as unknown as ReturnType<typeof readdirSync>[0],
+    ]);
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ folder: '/project/modern' }));
+
+    // Only signal is a pointer key; its GUID cannot be confirmed without global storage.
+    const wsDb = createWorkspaceDbWithPointers(JSON.stringify({ selectedComposerIds: [] }), [
+      { key: 'workbench.panel.composerChatViewPane.aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', value: '{}' },
+    ]);
+    mockOpenDatabase.mockResolvedValue(wsDb);
+
+    const result = await findWorkspaces('/data');
+    // Pointer GUID is not counted (no phantom session), so the workspace is excluded.
+    expect(result).toHaveLength(0);
+  });
+});
+
+// =============================================================================
+// getWorkspaceLinkedComposerIds — ownership guard for pointer-linked composers
+// =============================================================================
+describe('getWorkspaceLinkedComposerIds', () => {
+  it('includes owned and unstamped pointer composers but excludes ones stamped for another workspace', async () => {
+    const ownedId = '11111111-1111-1111-1111-111111111111';
+    const orphanId = '22222222-2222-2222-2222-222222222222';
+    const foreignId = '33333333-3333-3333-3333-333333333333';
+
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const path = String(p);
+      return path.includes('state.vscdb') || path.includes('globalStorage/state.vscdb');
+    });
+
+    const wsDb = createWorkspaceDbWithPointers(JSON.stringify({ selectedComposerIds: [] }), [
+      { key: `workbench.panel.composerChatViewPane.${ownedId}`, value: '{}' },
+      { key: `workbench.panel.composerChatViewPane.${orphanId}`, value: '{}' },
+      { key: `workbench.panel.composerChatViewPane.${foreignId}`, value: '{}' },
+    ]);
+    const globalDb = createGlobalDbForComposerMap({
+      [ownedId]: {
+        composerData: { name: 'Owned', workspaceIdentifier: { uri: { fsPath: '/my/project' } } },
+        bubbles: [{ type: 1, text: 'owned' }],
+      },
+      [orphanId]: {
+        composerData: { name: 'Orphan' },
+        bubbles: [{ type: 1, text: 'orphan' }],
+      },
+      [foreignId]: {
+        composerData: { name: 'Foreign', workspaceIdentifier: { uri: { fsPath: '/other/project' } } },
+        bubbles: [{ type: 1, text: 'foreign' }],
+      },
+    });
+
+    mockOpenDatabase.mockImplementation(async (path: string) =>
+      String(path).includes('globalStorage') ? globalDb : wsDb
+    );
+
+    const result = await getWorkspaceLinkedComposerIds({
+      id: 'ws-mine',
+      path: '/my/project',
+      dbPath: '/ws-mine/state.vscdb',
+      sessionCount: 0,
+    });
+
+    expect(result).toEqual(expect.arrayContaining([ownedId, orphanId]));
+    expect(result).not.toContain(foreignId);
   });
 });
 
@@ -859,6 +962,84 @@ describe('listSessions', () => {
     const ids = result.map((s) => s.id);
     expect(ids).toEqual(expect.arrayContaining(['a-own', 'b-own', 'shared']));
     expect(ids.filter((id) => id === 'shared')).toHaveLength(1);
+  });
+
+  it('attributes global composers via composerChatViewPane pointer keys (no workspace stamp)', async () => {
+    const guid = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const path = String(p);
+      return (
+        path.includes('state.vscdb') ||
+        path.includes('workspace.json') ||
+        path === '/data' ||
+        path.includes('globalStorage/state.vscdb')
+      );
+    });
+    vi.mocked(readdirSync).mockReturnValue([
+      { name: 'ws-modern', isDirectory: () => true } as unknown as ReturnType<typeof readdirSync>[0],
+    ]);
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ folder: '/project/modern' }));
+
+    // Workspace composer data is essentially empty; the only link is the pointer key.
+    const wsDb = createWorkspaceDbWithPointers(JSON.stringify({ selectedComposerIds: [] }), [
+      { key: `workbench.panel.composerChatViewPane.${guid}`, value: '{}' },
+    ]);
+    // Global record has NO workspaceUri / workspaceIdentifier.
+    const globalDb = createGlobalDbForComposerMap({
+      [guid]: {
+        composerData: { name: 'Pointer Session', createdAt: 1778672423842, lastUpdatedAt: 1778682083842 },
+        bubbles: [{ type: 1, text: 'pointer-linked prompt' }],
+      },
+    });
+
+    mockOpenDatabase.mockImplementation(async (path: string) =>
+      String(path).includes('globalStorage') ? globalDb : wsDb
+    );
+
+    const result = await listSessions({ limit: 10, all: false }, '/data');
+    expect(result).toHaveLength(1);
+    expect(result[0]!.id).toBe(guid);
+    expect(result[0]!.workspaceId).toBe('ws-modern');
+    expect(result[0]!.workspacePath).toBe('/project/modern');
+  });
+
+  it('surfaces unattributed global composers via the catch-all under a global bucket', async () => {
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const path = String(p);
+      return (
+        path.includes('state.vscdb') ||
+        path.includes('workspace.json') ||
+        path === '/data' ||
+        path.includes('globalStorage/state.vscdb')
+      );
+    });
+    vi.mocked(readdirSync).mockReturnValue([
+      { name: 'ws1', isDirectory: () => true } as unknown as ReturnType<typeof readdirSync>[0],
+    ]);
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ folder: '/project/x' }));
+
+    const wsDb = createWorkspaceDb(JSON.stringify({ selectedComposerIds: ['ws-own'] }));
+    const globalDb = createGlobalDbForComposerMap({
+      'ws-own': {
+        composerData: { name: 'Owned', createdAt: 1778672423842, lastUpdatedAt: 1778672423842 },
+        bubbles: [{ type: 1, text: 'owned' }],
+      },
+      // Not referenced by any workspace and carries no workspace metadata.
+      'orphan-1': {
+        composerData: { name: 'Orphan', createdAt: 1778672423842, lastUpdatedAt: 1778672423842 },
+        bubbles: [{ type: 1, text: 'orphan' }],
+      },
+    });
+
+    mockOpenDatabase.mockImplementation(async (path: string) =>
+      String(path).includes('globalStorage') ? globalDb : wsDb
+    );
+
+    const result = await listSessions({ limit: 50, all: true }, '/data');
+    const byId = new Map(result.map((s) => [s.id, s]));
+    expect(byId.get('ws-own')?.workspaceId).toBe('ws1');
+    expect(byId.get('orphan-1')).toBeDefined();
+    expect(byId.get('orphan-1')!.workspaceId).toBe('global');
   });
 
   it('skips selectedComposerIds fallback entries that have no global bubbles', async () => {


### PR DESCRIPTION
## Summary

Fixes [Issue #29](https://github.com/S2thend/cursor-history/issues/29): recent sessions/workspaces not being listed correctly, and migration/listing inconsistencies that made sessions appear missing or empty after workspace moves.

### What changed

- Improved session discovery/parsing:
  - support root-level composer arrays in parser
  - prefer chat data keys that produce valid sessions
  - support `selectedComposerIds` fallback when workspace data is header-only and global bubbles exist
  - ignore stale selected IDs that have no global bubbles

- Fixed migration behavior for modern Cursor data shapes:
  - support `selectedComposerIds`-only workspace data in migration paths
  - hydrate migrated composer headers from global `composerData` so migrated entries are not `(Empty session)`
  - update global `composerData.workspaceUri` on move/copy so Cursor can associate chats with destination workspace
  - allow destination workspace lookup even when it currently has zero sessions

- Added regression coverage in:
  - `tests/unit/parser.test.ts`
  - `tests/unit/storage.test.ts`
  - `tests/unit/migrate.test.ts`

## Why this fixes #29

Issue #29 reports missing recent sessions. The root cause was schema drift in Cursor workspace/global storage:
- some workspaces only had selected composer IDs
- key selection and fallback behavior diverged between list and migrate
- migrated records could lose display metadata or workspace linkage

This PR aligns those paths so recent sessions are discoverable and remain visible/usable after migration.

## Validation

- `npm test`
- `npm run lint`
- `npm run typecheck`

All passing.