### PR TITLE
fix(backup): support databases larger than 2 GiB via streaming + gzip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **Backups of databases larger than 2 GiB**: `backup` crashed with `File size (...) is greater than 2 GiB` (`ERR_FS_FILE_TOO_LARGE`) as soon as `globalStorage/state.vscdb` passed 2 GiB, because every file was read into a Buffer for checksumming and zipping. Backup, validate, restore and backup browsing are now fully stream based, and database files are stored gzipped inside the archive (zip members must stay below 2 GiB to be readable, and archives get considerably smaller). Backups written by older versions still restore unchanged.
 - **Tool content normalization**: `Message.content` now preserves full payloads for `read_file_v2`, `edit_file_v2`, legacy `read_file`, terminal-command output, and generic tool params/results. Default CLI previews are unchanged; `show --tool` still expands full tool content in the terminal.
 - **Session data integrity**: `getSession()` and `getGlobalSession()` now preserve empty bubbles as `[empty message]`, retain malformed global rows as `[corrupted message]` placeholders with `metadata.corrupted = true`, and populate `message.metadata.bubbleType` when the source bubble type is known.
 - **Structured tool call recovery**: `message.toolCalls` is now populated from `toolFormerData`, including default `completed` status handling and `{ _raw: ... }` sentinels when tool params contain invalid JSON.

--- a/src/cli/commands/backup.ts
+++ b/src/cli/commands/backup.ts
@@ -26,7 +26,10 @@ function formatSize(bytes: number): string {
   if (bytes < 1024 * 1024) {
     return `${(bytes / 1024).toFixed(1)} KB`;
   }
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  if (bytes < 1024 * 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
 }
 
 /**
@@ -53,10 +56,15 @@ function displayProgress(progress: BackupProgress): void {
   const phaseText = phases[progress.phase];
   const fileProgress =
     progress.totalFiles > 0 ? ` [${progress.filesCompleted}/${progress.totalFiles}]` : '';
+  // Compressing a multi-GB database takes a while, show how far along it is
+  const percent =
+    progress.phase === 'compressing' && progress.totalBytes > 0
+      ? ` ${Math.min(100, Math.round((progress.bytesCompleted / progress.totalBytes) * 100))}%`
+      : '';
   const currentFile = progress.currentFile ? ` ${pc.dim(progress.currentFile)}` : '';
 
   // Clear line and print progress
-  process.stdout.write(`\r${phaseText}${fileProgress}${currentFile}`.padEnd(80));
+  process.stdout.write(`\r${phaseText}${fileProgress}${percent}${currentFile}`.padEnd(80));
 }
 
 /**

--- a/src/core/backup.ts
+++ b/src/core/backup.ts
@@ -15,17 +15,25 @@ import {
   readdirSync,
   statSync,
   unlinkSync,
-  readFileSync,
-  writeFileSync,
+  copyFileSync,
   rmdirSync,
 } from 'node:fs';
-import { readFile, writeFile } from 'node:fs/promises';
 import { homedir, tmpdir } from 'node:os';
 import { join, dirname, sep } from 'node:path';
 import JSZip from 'jszip';
 import type { Database as DatabaseInterface, Statement } from './database/types.js';
 import { registry } from './database/registry.js';
 import { backupDatabase } from './database/index.js';
+import {
+  MAX_ZIP_ENTRY_BYTES,
+  computeFileChecksum,
+  computeZipEntryChecksum,
+  createByteCounter,
+  createGzipFileStream,
+  extractZipEntryToFile,
+  readFileBuffer,
+  writeZipToFile,
+} from './stream-io.js';
 import type {
   BackupManifest,
   BackupFileEntry,
@@ -59,6 +67,25 @@ export function getDefaultBackupDir(): string {
  */
 export function computeChecksum(buffer: Buffer): string {
   return `sha256:${createHash('sha256').update(buffer).digest('hex')}`;
+}
+
+/**
+ * Name of the zip member holding a manifest entry.
+ * Gzipped files get a `.gz` suffix; older backups stored the raw file.
+ */
+function zipEntryName(entry: Pick<BackupFileEntry, 'path' | 'compression'>): string {
+  return entry.compression === 'gzip' ? `${entry.path}.gz` : entry.path;
+}
+
+/** Delete a file, ignoring any error (used to drop half written archives). */
+function removeFileQuietly(filePath: string): void {
+  try {
+    if (existsSync(filePath)) {
+      unlinkSync(filePath);
+    }
+  } catch {
+    // Ignore cleanup errors
+  }
 }
 
 /**
@@ -341,20 +368,22 @@ export async function createBackup(config?: BackupConfig): Promise<BackupResult>
         // T011: Backup database using SQLite backup API
         await backupDatabase(dbFile.absolutePath, tempFilePath);
       } else {
-        // For non-DB files (like workspace.json), just copy
-        const content = readFileSync(dbFile.absolutePath);
-        writeFileSync(tempFilePath, content);
+        // For non-DB files (like workspace.json), copy at the filesystem level
+        // (readFileSync would fail on files above 2 GiB)
+        copyFileSync(dbFile.absolutePath, tempFilePath);
       }
 
-      // Read backed up file and compute checksum
-      const buffer = readFileSync(tempFilePath);
-      const checksum = computeChecksum(buffer);
+      // Checksum the backed up file with a streaming hash: reading it into a
+      // Buffer throws ERR_FS_FILE_TOO_LARGE once a database passes 2 GiB
+      const checksum = await computeFileChecksum(tempFilePath);
+      const backedUpSize = statSync(tempFilePath).size;
 
       fileEntries.push({
-        path: dbFile.relativePath,
-        size: buffer.length,
+        path: dbFile.relativePath.split(sep).join('/'),
+        size: backedUpSize,
         checksum,
         type: dbFile.type,
+        compression: 'gzip',
       });
 
       // Count sessions (only for DB files)
@@ -368,26 +397,21 @@ export async function createBackup(config?: BackupConfig): Promise<BackupResult>
       bytesCompleted += dbFile.size;
     }
 
-    // Phase: Compressing
-    onProgress?.({
-      phase: 'compressing',
-      filesCompleted: dbFiles.length,
-      totalFiles: dbFiles.length,
-      bytesCompleted: totalBytes,
-      totalBytes,
-    });
-
     // T014: Create zip file
     const zip = new JSZip();
 
-    // Add all backed up database files
-    for (const entry of fileEntries) {
+    // Add every file as a gzip stream: databases are never loaded into memory
+    // (readFileSync throws ERR_FS_FILE_TOO_LARGE above 2 GiB) and gzipping them
+    // up front keeps each zip member small enough to be read back later.
+    const storedSizes = fileEntries.map((entry) => {
       const filePath = join(tempDir, entry.path);
-      // Convert path to use forward slashes for cross-platform compatibility
-      const zipPath = entry.path.split(sep).join('/');
-      const fileContent = readFileSync(filePath);
-      zip.file(zipPath, fileContent);
-    }
+      const counter = createByteCounter();
+      // Already gzipped, so let jszip store the bytes as they are
+      zip.file(zipEntryName(entry), createGzipFileStream(filePath).pipe(counter), {
+        compression: 'STORE',
+      });
+      return { entry, counter };
+    });
 
     // T015: Create and add manifest
     const stats: BackupStats = {
@@ -398,6 +422,61 @@ export async function createBackup(config?: BackupConfig): Promise<BackupResult>
     const manifest = createManifest(fileEntries, stats);
     zip.file('manifest.json', JSON.stringify(manifest, null, 2));
 
+    // Phase: Compressing
+    onProgress?.({
+      phase: 'compressing',
+      filesCompleted: dbFiles.length,
+      totalFiles: dbFiles.length,
+      bytesCompleted: 0,
+      totalBytes,
+    });
+
+    // Write zip file
+    if (existsSync(outputPath)) {
+      unlinkSync(outputPath);
+    }
+
+    let lastPercent = -1;
+    try {
+      await writeZipToFile(zip, outputPath, {
+        onUpdate: (metadata) => {
+          // jszip fires this for every chunk, throttle to whole percents
+          const percent = Math.floor(metadata.percent);
+          if (percent === lastPercent) {
+            return;
+          }
+          lastPercent = percent;
+          onProgress?.({
+            phase: 'compressing',
+            currentFile: metadata.currentFile ?? undefined,
+            filesCompleted: dbFiles.length,
+            totalFiles: dbFiles.length,
+            bytesCompleted: Math.round((percent / 100) * totalBytes),
+            totalBytes,
+          });
+        },
+      });
+    } catch (e) {
+      removeFileQuietly(outputPath);
+      throw e;
+    }
+
+    // A member of 2 GiB or more cannot be read back (32 bit signed zip headers),
+    // so refuse to hand out a backup that could never be restored
+    const oversized = storedSizes.find(({ counter }) => counter.bytes > MAX_ZIP_ENTRY_BYTES);
+    if (oversized) {
+      removeFileQuietly(outputPath);
+      return {
+        success: false,
+        backupPath: outputPath,
+        manifest: createManifest([], { totalSize: 0, sessionCount: 0, workspaceCount: 0 }),
+        durationMs: Date.now() - startTime,
+        error:
+          `${oversized.entry.path} is too large to archive: ${oversized.counter.bytes} compressed ` +
+          `bytes exceed the 2 GiB zip member limit. Copy the database manually instead.`,
+      };
+    }
+
     // Phase: Finalizing
     onProgress?.({
       phase: 'finalizing',
@@ -406,13 +485,6 @@ export async function createBackup(config?: BackupConfig): Promise<BackupResult>
       bytesCompleted: totalBytes,
       totalBytes,
     });
-
-    // Write zip file
-    if (existsSync(outputPath)) {
-      unlinkSync(outputPath);
-    }
-    const zipContent = await zip.generateAsync({ type: 'nodebuffer' });
-    await writeFile(outputPath, zipContent);
 
     return {
       success: true,
@@ -491,22 +563,23 @@ export async function openBackupDatabase(
   backupPath: string,
   dbPath: string
 ): Promise<DatabaseInterface> {
-  const data = await readFile(backupPath);
+  const data = await readFileBuffer(backupPath);
   const zip = await JSZip.loadAsync(data);
-  const dbFile = zip.file(dbPath);
+  // Current backups store databases gzipped, older ones stored them as is
+  const gzipped = zip.file(`${dbPath}.gz`);
+  const dbFile = gzipped ?? zip.file(dbPath);
 
   if (!dbFile) {
     throw new Error(`Database not found in backup: ${dbPath}`);
   }
 
-  const buffer = await dbFile.async('nodebuffer');
-
-  // Extract to temp file since SQLite needs file access
+  // Extract to temp file since SQLite needs file access.
+  // Streamed so that multi-GB databases don't have to fit in a Buffer.
   const tempFile = join(
     tmpdir(),
     `cursor_history_backup_${Date.now()}_${Math.random().toString(36).slice(2)}.vscdb`
   );
-  writeFileSync(tempFile, buffer);
+  await extractZipEntryToFile(dbFile, tempFile, { gunzip: gzipped !== null });
 
   // Use pluggable driver system - registry.openSync requires driver to already be selected
   let db: DatabaseInterface | null = null;
@@ -532,7 +605,7 @@ export async function openBackupDatabase(
  */
 export async function readBackupManifest(backupPath: string): Promise<BackupManifest | null> {
   try {
-    const data = await readFile(backupPath);
+    const data = await readFileBuffer(backupPath);
     const zip = await JSZip.loadAsync(data);
     const manifestFile = zip.file('manifest.json');
     if (!manifestFile) {
@@ -568,7 +641,7 @@ export async function validateBackup(backupPath: string): Promise<BackupValidati
   // Try to open as zip
   let zip: JSZip;
   try {
-    const data = await readFile(backupPath);
+    const data = await readFileBuffer(backupPath);
     zip = await JSZip.loadAsync(data);
   } catch (e) {
     return {
@@ -608,14 +681,16 @@ export async function validateBackup(backupPath: string): Promise<BackupValidati
 
   // Verify each file
   for (const fileEntry of manifest.files) {
-    const file = zip.file(fileEntry.path);
+    const file = zip.file(zipEntryName(fileEntry));
     if (!file) {
       missingFiles.push(fileEntry.path);
       continue;
     }
 
-    const buffer = await file.async('nodebuffer');
-    const actualChecksum = computeChecksum(buffer);
+    // Hash while inflating: entries can be several GB
+    const actualChecksum = await computeZipEntryChecksum(file, {
+      gunzip: fileEntry.compression === 'gzip',
+    });
     if (actualChecksum === fileEntry.checksum) {
       validFiles.push(fileEntry.path);
     } else {
@@ -712,7 +787,7 @@ export async function restoreBackup(config: RestoreConfig): Promise<RestoreResul
   });
 
   // Phase: Extracting
-  const data = await readFile(backupPath);
+  const data = await readFileBuffer(backupPath);
   const zip = await JSZip.loadAsync(data);
   const restoredFiles: string[] = [];
   const warnings: string[] = validation.corruptedFiles.map((f) => `Checksum mismatch: ${f}`);
@@ -730,12 +805,10 @@ export async function restoreBackup(config: RestoreConfig): Promise<RestoreResul
         corruptedFiles: validation.corruptedFiles,
       });
 
-      const file = zip.file(fileEntry.path);
+      const file = zip.file(zipEntryName(fileEntry));
       if (!file) {
         continue; // Skip missing files
       }
-
-      const buffer = await file.async('nodebuffer');
 
       // Convert forward slashes to platform-specific separators
       const platformPath = fileEntry.path.split('/').join(sep);
@@ -744,8 +817,10 @@ export async function restoreBackup(config: RestoreConfig): Promise<RestoreResul
       // Create directory structure
       mkdirSync(dirname(destPath), { recursive: true });
 
-      // Write file
-      writeFileSync(destPath, buffer);
+      // Stream the entry to disk (databases can be several GB)
+      await extractZipEntryToFile(file, destPath, {
+        gunzip: fileEntry.compression === 'gzip',
+      });
       restoredFiles.push(fileEntry.path);
     }
 

--- a/src/core/storage.ts
+++ b/src/core/storage.ts
@@ -3,8 +3,8 @@
  */
 
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
-import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { gunzipSync } from 'node:zlib';
 import JSZip from 'jszip';
 import {
   openDatabase as openDatabaseAsync,
@@ -35,6 +35,7 @@ import {
 import { SessionNotFoundError } from '../lib/errors.js';
 import { parseChatData, getSearchSnippets, type CursorChatBundle } from './parser.js';
 import { openBackupDatabase, readBackupManifest } from './backup.js';
+import { readFileBuffer } from './stream-io.js';
 import { debugLogStorage } from './database/debug.js';
 
 /**
@@ -579,16 +580,20 @@ async function readWorkspaceJsonFromBackup(
   workspaceId: string
 ): Promise<string | null> {
   try {
-    const data = await readFile(backupPath);
+    const data = await readFileBuffer(backupPath);
     const zip = await JSZip.loadAsync(data);
     const jsonPath = `workspaceStorage/${workspaceId}/workspace.json`;
-    const file = zip.file(jsonPath);
+    // Current backups gzip their members, older ones stored them as is
+    const gzipped = zip.file(`${jsonPath}.gz`);
+    const file = gzipped ?? zip.file(jsonPath);
 
     if (!file) {
       return null;
     }
 
-    const buffer = await file.async('nodebuffer');
+    const buffer = gzipped
+      ? gunzipSync(await gzipped.async('nodebuffer'))
+      : await file.async('nodebuffer');
     const content = buffer.toString('utf-8');
     const jsonData = JSON.parse(content) as WorkspaceJsonShape;
     return getWorkspacePathFromJson(jsonData);

--- a/src/core/stream-io.ts
+++ b/src/core/stream-io.ts
@@ -1,0 +1,216 @@
+/**
+ * Streaming I/O helpers for the backup / restore pipeline.
+ *
+ * Cursor's `globalStorage/state.vscdb` routinely grows to several GB. Node.js
+ * refuses to `fs.readFile()` / `fs.readFileSync()` anything larger than 2 GiB
+ * and throws `ERR_FS_FILE_TOO_LARGE` ("File size (...) is greater than 2 GiB").
+ * Every place that used to slurp a whole database into a Buffer therefore has
+ * to work with streams instead, which also keeps memory usage flat.
+ */
+
+import { createHash } from 'node:crypto';
+import { createReadStream, createWriteStream } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { Transform, Writable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import { createGunzip, createGzip } from 'node:zlib';
+
+/** Hard limit of `fs.readFile()` / `fs.readFileSync()` (2 GiB - 1 bytes). */
+export const MAX_READ_FILE_BYTES = 2 ** 31 - 1;
+
+/**
+ * Largest zip member that can be read back.
+ *
+ * jszip parses 32 bit header fields with `(result << 8) + byte`, a signed
+ * operation, so any member of 2 GiB or more is read as a negative size and
+ * fails with "Bug : uncompressed data size mismatch". Databases are therefore
+ * gzipped before being stored (see `createGzipFileStream`), which keeps members
+ * far below this limit.
+ */
+export const MAX_ZIP_ENTRY_BYTES = 2 ** 31 - 1;
+
+/** Progress metadata emitted by jszip while an archive is generated. */
+export interface ZipUpdateMetadata {
+  percent: number;
+  currentFile: string | null;
+}
+
+/** Minimal structural view of a JSZip instance (keeps this module test friendly). */
+export interface ZipGeneratorLike {
+  generateNodeStream(
+    options?: {
+      type?: 'nodebuffer';
+      streamFiles?: boolean;
+      compression?: 'STORE' | 'DEFLATE';
+      compressionOptions?: { level: number };
+    },
+    onUpdate?: (metadata: ZipUpdateMetadata) => void
+  ): NodeJS.ReadableStream;
+}
+
+/** Minimal structural view of a JSZip entry. */
+export interface ZipEntryLike {
+  nodeStream(type?: 'nodebuffer'): NodeJS.ReadableStream;
+}
+
+export interface WriteZipOptions {
+  /** Compression method, defaults to DEFLATE (a stored 3 GB database stays 3 GB). */
+  compression?: 'STORE' | 'DEFLATE';
+  /** DEFLATE level 1-9, defaults to 6. */
+  compressionLevel?: number;
+  /** Called repeatedly while the archive is written. */
+  onUpdate?: (metadata: ZipUpdateMetadata) => void;
+}
+
+function isFileTooLargeError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    (error as NodeJS.ErrnoException).code === 'ERR_FS_FILE_TOO_LARGE'
+  );
+}
+
+async function hashStream(stream: NodeJS.ReadableStream): Promise<string> {
+  const hash = createHash('sha256');
+
+  // pipeline() instead of `for await`: jszip entry streams are readable-stream
+  // v2 objects and are not async iterable
+  await pipeline(
+    stream,
+    new Writable({
+      write(chunk: Buffer, _encoding, callback) {
+        hash.update(chunk);
+        callback();
+      },
+    })
+  );
+
+  return `sha256:${hash.digest('hex')}`;
+}
+
+/**
+ * SHA-256 of a file, computed chunk by chunk.
+ * Works for files of any size and never allocates more than one chunk.
+ */
+export async function computeFileChecksum(filePath: string): Promise<string> {
+  return hashStream(createReadStream(filePath));
+}
+
+/**
+ * SHA-256 of a zip entry, computed while the entry is being inflated.
+ * With `gunzip` the hash is taken from the decompressed payload, i.e. it can be
+ * compared against the checksum of the original file.
+ */
+export async function computeZipEntryChecksum(
+  entry: ZipEntryLike,
+  options: { gunzip?: boolean } = {}
+): Promise<string> {
+  const source = entry.nodeStream('nodebuffer');
+  if (!options.gunzip) {
+    return hashStream(source);
+  }
+
+  const gunzip = createGunzip();
+  source.on('error', (error: Error) => gunzip.destroy(error));
+  return hashStream(source.pipe(gunzip));
+}
+
+/** Extract a zip entry directly to disk without buffering it in memory. */
+export async function extractZipEntryToFile(
+  entry: ZipEntryLike,
+  destPath: string,
+  options: { gunzip?: boolean } = {}
+): Promise<void> {
+  const source = entry.nodeStream('nodebuffer');
+  const stages: NodeJS.ReadableStream[] = [source];
+
+  if (options.gunzip) {
+    const gunzip = createGunzip();
+    source.on('error', (error: Error) => gunzip.destroy(error));
+    stages.push(source.pipe(gunzip));
+  }
+
+  await pipeline(stages[stages.length - 1]!, createWriteStream(destPath));
+}
+
+/**
+ * Read a file as a gzip compressed stream.
+ *
+ * Storing databases gzipped keeps every zip member well under the 2 GiB the zip
+ * reader can handle, and gzip (native zlib) is both faster and stronger than
+ * jszip's JavaScript deflate.
+ */
+export function createGzipFileStream(filePath: string, level = 6): NodeJS.ReadableStream {
+  const source = createReadStream(filePath);
+  const gzip = createGzip({ level });
+  // .pipe() does not forward errors, do it manually so jszip sees the failure
+  source.on('error', (error: Error) => gzip.destroy(error));
+  return source.pipe(gzip);
+}
+
+/** Counts the bytes flowing through it, used to measure stored zip members. */
+export interface ByteCounter extends Transform {
+  readonly bytes: number;
+}
+
+export function createByteCounter(): ByteCounter {
+  let bytes = 0;
+  const counter = new Transform({
+    transform(chunk: Buffer, _encoding, callback) {
+      bytes += chunk.length;
+      callback(null, chunk);
+    },
+  });
+  Object.defineProperty(counter, 'bytes', { get: () => bytes });
+  return counter as ByteCounter;
+}
+
+/**
+ * Write a zip archive straight to disk.
+ *
+ * `generateAsync({ type: 'nodebuffer' })` materialises the whole archive in a
+ * single Buffer, which is impossible for multi-GB backups. `generateNodeStream`
+ * streams it out instead; `streamFiles: true` is required because entries added
+ * as streams have an unknown size/CRC upfront (jszip then uses data descriptors
+ * rather than buffering each entry to measure it).
+ */
+export async function writeZipToFile(
+  zip: ZipGeneratorLike,
+  outputPath: string,
+  options: WriteZipOptions = {}
+): Promise<void> {
+  const stream = zip.generateNodeStream(
+    {
+      type: 'nodebuffer',
+      streamFiles: true,
+      compression: options.compression ?? 'DEFLATE',
+      compressionOptions: { level: options.compressionLevel ?? 6 },
+    },
+    options.onUpdate
+  );
+
+  await pipeline(stream, createWriteStream(outputPath));
+}
+
+/**
+ * Read a whole file into memory, transparently falling back to a streamed read
+ * when the file exceeds the 2 GiB `fs.readFile()` limit.
+ *
+ * Used for zip archives only: jszip can merely parse in-memory archives, so the
+ * container itself still has to fit in a Buffer (entries inside are streamed).
+ */
+export async function readFileBuffer(filePath: string): Promise<Buffer> {
+  try {
+    return await readFile(filePath);
+  } catch (error) {
+    if (!isFileTooLargeError(error)) {
+      throw error;
+    }
+
+    const chunks: Buffer[] = [];
+    for await (const chunk of createReadStream(filePath)) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string));
+    }
+    return Buffer.concat(chunks);
+  }
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -303,14 +303,21 @@ export interface BackupManifest {
  * A single file entry in the backup manifest
  */
 export interface BackupFileEntry {
-  /** Path within zip (forward slashes, relative to zip root) */
+  /** Logical path (forward slashes, relative to zip root) */
   path: string;
   /** Original file size in bytes */
   size: number;
-  /** SHA-256 checksum for integrity verification */
+  /** SHA-256 checksum of the original file, for integrity verification */
   checksum: string;
   /** File type for categorization */
   type: 'global-db' | 'workspace-db' | 'workspace-json' | 'manifest';
+  /**
+   * How the file is encoded inside the zip. When 'gzip' the zip entry is
+   * `${path}.gz` and holds gzipped data (keeps entries small enough for the
+   * zip reader, which cannot handle members of 2 GiB or more).
+   * Absent in backups created before this was introduced.
+   */
+  compression?: 'gzip';
 }
 
 /**

--- a/tests/unit/backup.test.ts
+++ b/tests/unit/backup.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
+import { Readable, Writable } from 'node:stream';
 
 // Mock node:fs
 vi.mock('node:fs', async () => {
@@ -15,6 +16,9 @@ vi.mock('node:fs', async () => {
     statSync: vi.fn(),
     unlinkSync: vi.fn(),
     rmdirSync: vi.fn(),
+    copyFileSync: vi.fn(),
+    createReadStream: vi.fn(),
+    createWriteStream: vi.fn(),
   };
 });
 
@@ -44,24 +48,52 @@ vi.mock('../../src/core/database/index.js', () => ({
 }));
 
 // Mock jszip - vi.hoisted ensures variables are available in hoisted vi.mock
-const { mockZipFile, mockZipGenerateAsync, mockZipLoadAsync } = vi.hoisted(() => ({
-  mockZipFile: vi.fn(),
-  mockZipGenerateAsync: vi.fn(),
-  mockZipLoadAsync: vi.fn(),
-}));
+const { mockZipFile, mockZipGenerateAsync, mockZipGenerateNodeStream, mockZipLoadAsync } =
+  vi.hoisted(() => ({
+    mockZipFile: vi.fn(),
+    mockZipGenerateAsync: vi.fn(),
+    mockZipGenerateNodeStream: vi.fn(),
+    mockZipLoadAsync: vi.fn(),
+  }));
 
 vi.mock('jszip', () => {
   function MockJSZip() {
     return {
       file: mockZipFile,
       generateAsync: mockZipGenerateAsync,
+      generateNodeStream: mockZipGenerateNodeStream,
     };
   }
   MockJSZip.loadAsync = mockZipLoadAsync;
   return { default: MockJSZip };
 });
 
-import { existsSync, mkdirSync, readdirSync, statSync, readFileSync } from 'node:fs';
+/** Zip entry mock exposing both the buffer and the streaming API. */
+function zipEntry(content: Buffer) {
+  return {
+    async: vi.fn().mockResolvedValue(content),
+    nodeStream: vi.fn(() => Readable.from([content])),
+  };
+}
+
+/** Writable that swallows everything (stand-in for fs.createWriteStream). */
+function sinkStream() {
+  return new Writable({
+    write(_chunk, _encoding, callback) {
+      callback();
+    },
+  });
+}
+
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  statSync,
+  readFileSync,
+  createReadStream,
+  createWriteStream,
+} from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import {
   getDefaultBackupDir,
@@ -291,10 +323,10 @@ describe('validateBackup', () => {
     mockZipLoadAsync.mockResolvedValue({
       file: vi.fn((name: string) => {
         if (name === 'manifest.json') {
-          return { async: vi.fn().mockResolvedValue(Buffer.from(JSON.stringify(manifest))) };
+          return zipEntry(Buffer.from(JSON.stringify(manifest)));
         }
         if (name === 'test.db') {
-          return { async: vi.fn().mockResolvedValue(fileContent) };
+          return zipEntry(fileContent);
         }
         return null;
       }),
@@ -393,14 +425,52 @@ describe('createBackup', () => {
     });
     vi.mocked(statSync).mockReturnValue({ size: 1024 } as ReturnType<typeof statSync>);
     vi.mocked(readFileSync).mockReturnValue(Buffer.from('database-content'));
-
-    const { writeFile: mockWriteFile } = await import('node:fs/promises');
-    vi.mocked(mockWriteFile).mockResolvedValue(undefined);
-    mockZipGenerateAsync.mockResolvedValue(Buffer.from('zipdata'));
+    // Files are hashed and zipped through streams
+    vi.mocked(createReadStream).mockImplementation(
+      () => Readable.from([Buffer.from('database-content')]) as unknown as ReturnType<
+        typeof createReadStream
+      >
+    );
+    vi.mocked(createWriteStream).mockImplementation(
+      () => sinkStream() as unknown as ReturnType<typeof createWriteStream>
+    );
+    mockZipGenerateNodeStream.mockImplementation(() => Readable.from([Buffer.from('zipdata')]));
 
     const result = await createBackup({ outputPath: '/backups/test.zip' });
     expect(result.success).toBe(true);
     expect(result.manifest.files.length).toBeGreaterThan(0);
+    // Never buffer the whole archive in memory
+    expect(mockZipGenerateAsync).not.toHaveBeenCalled();
+    expect(mockZipGenerateNodeStream).toHaveBeenCalledWith(
+      expect.objectContaining({ streamFiles: true }),
+      expect.any(Function)
+    );
+  });
+
+  it('reports compression progress while writing the archive', async () => {
+    vi.mocked(mkdirSync).mockImplementation(() => undefined as unknown as string);
+    vi.mocked(existsSync).mockImplementation((p) => !String(p).endsWith('.zip'));
+    vi.mocked(readdirSync).mockImplementation(() => []);
+    vi.mocked(statSync).mockReturnValue({ size: 1024 } as ReturnType<typeof statSync>);
+    vi.mocked(createReadStream).mockImplementation(
+      () => Readable.from([Buffer.from('database-content')]) as unknown as ReturnType<
+        typeof createReadStream
+      >
+    );
+    vi.mocked(createWriteStream).mockImplementation(
+      () => sinkStream() as unknown as ReturnType<typeof createWriteStream>
+    );
+    mockZipGenerateNodeStream.mockImplementation(
+      (_options: unknown, onUpdate?: (m: { percent: number; currentFile: string | null }) => void) => {
+        onUpdate?.({ percent: 50, currentFile: 'globalStorage/state.vscdb' });
+        return Readable.from([Buffer.from('zipdata')]);
+      }
+    );
+
+    const progress = vi.fn();
+    await createBackup({ outputPath: '/backups/test.zip', onProgress: progress });
+
+    expect(progress).toHaveBeenCalledWith(expect.objectContaining({ phase: 'compressing' }));
   });
 });
 
@@ -436,10 +506,10 @@ describe('restoreBackup', () => {
     mockZipLoadAsync.mockResolvedValue({
       file: vi.fn((name: string) => {
         if (name === 'manifest.json') {
-          return { async: vi.fn().mockResolvedValue(Buffer.from(JSON.stringify(manifest))) };
+          return zipEntry(Buffer.from(JSON.stringify(manifest)));
         }
         if (name === 'globalStorage/state.vscdb') {
-          return { async: vi.fn().mockResolvedValue(fileContent) };
+          return zipEntry(fileContent);
         }
         return null;
       }),

--- a/tests/unit/stream-io.test.ts
+++ b/tests/unit/stream-io.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import JSZip from 'jszip';
+import {
+  computeFileChecksum,
+  computeZipEntryChecksum,
+  createByteCounter,
+  createGzipFileStream,
+  extractZipEntryToFile,
+  readFileBuffer,
+  writeZipToFile,
+} from '../../src/core/stream-io.js';
+import { computeChecksum } from '../../src/core/backup.js';
+
+describe('stream-io', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'cursor-history-stream-io-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writeFixture(name: string, content: Buffer | string): string {
+    const filePath = join(dir, name);
+    writeFileSync(filePath, content);
+    return filePath;
+  }
+
+  it('computes the same checksum as the buffer based helper', async () => {
+    const content = Buffer.from('a'.repeat(100_000));
+    const filePath = writeFixture('data.bin', content);
+
+    await expect(computeFileChecksum(filePath)).resolves.toBe(computeChecksum(content));
+  });
+
+  it('reads a file into a buffer', async () => {
+    const filePath = writeFixture('data.txt', 'hello');
+
+    await expect(readFileBuffer(filePath)).resolves.toEqual(Buffer.from('hello'));
+  });
+
+  it('round trips a file through a gzipped, streamed zip archive', async () => {
+    const content = Buffer.from(JSON.stringify({ rows: 'x'.repeat(200_000) }));
+    const filePath = writeFixture('state.vscdb', content);
+    const checksum = await computeFileChecksum(filePath);
+
+    const zip = new JSZip();
+    const counter = createByteCounter();
+    zip.file('globalStorage/state.vscdb.gz', createGzipFileStream(filePath).pipe(counter), {
+      compression: 'STORE',
+    });
+
+    const zipPath = join(dir, 'backup.zip');
+    await writeZipToFile(zip, zipPath);
+
+    // gzip must actually shrink the stored member
+    expect(counter.bytes).toBeGreaterThan(0);
+    expect(counter.bytes).toBeLessThan(content.length);
+    expect(statSync(zipPath).size).toBeGreaterThan(0);
+
+    const loaded = await JSZip.loadAsync(await readFileBuffer(zipPath));
+    const entry = loaded.file('globalStorage/state.vscdb.gz');
+    expect(entry).not.toBeNull();
+
+    // Checksum of the *original* content, verified through zip + gunzip
+    await expect(computeZipEntryChecksum(entry!, { gunzip: true })).resolves.toBe(checksum);
+
+    const restored = join(dir, 'restored.vscdb');
+    await extractZipEntryToFile(entry!, restored, { gunzip: true });
+    expect(readFileSync(restored)).toEqual(content);
+  });
+
+  it('round trips uncompressed entries (backups created by older versions)', async () => {
+    const content = Buffer.from('legacy entry');
+    const zip = new JSZip();
+    zip.file('globalStorage/state.vscdb', content);
+
+    const zipPath = join(dir, 'legacy.zip');
+    await writeZipToFile(zip, zipPath);
+
+    const loaded = await JSZip.loadAsync(await readFileBuffer(zipPath));
+    const entry = loaded.file('globalStorage/state.vscdb');
+    expect(entry).not.toBeNull();
+
+    await expect(computeZipEntryChecksum(entry!)).resolves.toBe(computeChecksum(content));
+
+    const restored = join(dir, 'legacy.vscdb');
+    await extractZipEntryToFile(entry!, restored);
+    expect(readFileSync(restored)).toEqual(content);
+  });
+
+  it('propagates read errors instead of writing a truncated archive', async () => {
+    const zip = new JSZip();
+    zip.file('missing.gz', createGzipFileStream(join(dir, 'does-not-exist')), {
+      compression: 'STORE',
+    });
+
+    await expect(writeZipToFile(zip, join(dir, 'broken.zip'))).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

`cursor-history backup` crashed with `File size (...) is greater than 2 GiB` (`ERR_FS_FILE_TOO_LARGE`) as soon as `globalStorage/state.vscdb` exceeded 2 GiB, because every file was read into a `Buffer` for checksumming and zipping.

There was also a latent bug: jszip parses 32-bit zip header sizes with signed arithmetic `(result << 8) + byte`, so any zip member **≥ 2 GiB reads back as a negative size** and fails with `Bug : uncompressed data size mismatch`. In other words, even a backup that wrote successfully could never be restored.

This PR makes the whole backup / validate / restore / browse pipeline stream based, and stores database members **gzipped** so each zip member stays well under 2 GiB.

## Root cause

- `fs.readFileSync` / `fs.readFile` have a hard 2 GiB ceiling.
- `zip.generateAsync({ type: 'nodebuffer' })` loaded the entire archive into memory.
- Read paths used `entry.async('nodebuffer')` + `writeFileSync(buffer)`.
- jszip does not emit ZIP64 and reads sizes as signed 32-bit, breaking members ≥ 2 GiB.

## Changes

- **New `src/core/stream-io.ts`**
  - `readFileBuffer()` — fall back to streamed read for files above the 2 GiB limit.
  - `computeFileChecksum()` / `computeZipEntryChecksum()` — streaming SHA-256 (optionally gunzip).
  - `extractZipEntryToFile()` — stream a zip entry to disk (optionally gunzip).
  - `createGzipFileStream()` — gzip a file as a stream; `createByteCounter()` — measure stored member size; `writeZipToFile()` — stream the archive to disk with progress.
  - `MAX_ZIP_ENTRY_BYTES` guard.
- **`src/core/backup.ts`**
  - Checksums via streaming hash; non-DB files copied with `copyFileSync`.
  - Databases added to the zip as gzip streams (`STORE`); members named `<path>.gz`; `compression: 'gzip'` recorded in the manifest.
  - Zip written via `generateNodeStream({ streamFiles: true })` with live compression-% progress.
  - Refuse (and delete) archives whose any member would exceed 2 GiB — otherwise the backup could never be read back.
  - validate / restore / open read `<path>.gz` with gunzip, falling back to the raw `<path>` for backups made before this change.
- **`src/core/storage.ts`** — browse-from-backup reads `workspace.json` with a gunzip fallback.
- **`src/core/types.ts`** — `BackupFileEntry.compression?: 'gzip'`.
- **`src/cli/commands/backup.ts`** — GB formatting in size display; live compression % in progress.
- **Tests** — new `tests/unit/stream-io.test.ts` (real-fs round trip) and extended `tests/unit/backup.test.ts` mocks for zip streaming.

## Testing

- Unit: `backup.test.ts` + `stream-io.test.ts` pass.
- Verified end-to-end on a real **3.55 GiB** `state.vscdb`:
  - backup produced a **0.99 GiB** zip (20 files, 10 workspaces, ~144 s);
  - `validateBackup` → `valid` (20 valid / 0 corrupt / 0 missing), confirming the streaming gunzip + SHA-256 round trip.

## Notes / risk

- Backups from older versions (no `compression` marker) **restore unchanged** (backward compatible).
- A single database still larger than ~2 GiB *after gzip* is rejected, since the zip format can't represent it; in practice Cursor's text-heavy history compresses well below that. If it ever trips, the error tells the user to copy the DB manually.
- Design docs under `specs/004-full-backup/` still describe the old in-memory approach and were left as-is (design history).